### PR TITLE
Extended permissions test

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -878,4 +878,9 @@ fn check_authorization() {
     deauthorize(principal1, Auth::Rpc);
     assert!(!is_authorized_principal(&principal1, Auth::Rpc));
     assert!(!is_authorized_principal(&principal2, Auth::Rpc));
+
+    // Test that a principal with the RegisterProvider permission does not have Admin permissions.
+    authorize(principal1, Auth::RegisterProvider);
+    assert!(!is_authorized_principal(&principal1, Auth::Admin));
+    assert!(is_authorized_principal(&principal1, Auth::RegisterProvider));
 }


### PR DESCRIPTION
Extended permissions test to validate the RpcProvider does not give Admin permissions.
