### PR TITLE
Simplify calling a specific EVM network

### DIFF
--- a/API.md
+++ b/API.md
@@ -30,7 +30,7 @@ Make a request to a Web2 Ethereum node using the caller's URL to an openly avail
 
 * `source`: Any of the following:
   * `#Url : text` The URL of the service, including any API key if required for access-protected services.
-  * `#Network : text` The relevant EVM network (using the [Alchemy naming convention](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/Network.md)).
+  * `#Chain : nat64` The relevant EVM network identifier ([reference list](https://chainlist.org/?testnets=true)).
   * `#Provider : nat64` The ID of the provider to be used for this call. Call `get_providers` to view a full list of providers.
 * `json_rpc_payload`: The payload for the JSON-RPC request. View examples in the [Ethereum documentation](https://ethereum.org/en/developers/docs/apis/json-rpc/).
 * `max_response_bytes`: The expected maximum size of the response of the Web2 API server. This parameter determines the network response size that is charged for. Not specifying it or it being larger than required may lead to substantial extra cycles cost for the HTTPS outcalls mechanism as its (large) default value is used and charged for.

--- a/API.md
+++ b/API.md
@@ -26,45 +26,27 @@ Confirm the authenticity of a message signed by an Ethereum private key. Check o
 
 Make a request to a Web2 Ethereum node using the caller's URL to an openly available JSON-RPC service, or the caller's URL (including an API key if necessary). No registered API key of the canister is used in this scenario.
 
-    request: (service_url: text, json_rpc_payload: text, max_response_bytes: nat64) -> (EthRpcResult);
+    request: (source: Source, json_rpc_payload: text, max_response_bytes: nat64) -> (EthRpcResult);
 
-* `service_url`: The URL of the service, including any API key if required for access-protected services.
+* `source`: Any of the following:
+  * `#Url : text` The URL of the service, including any API key if required for access-protected services.
+  * `#Network : text` The relevant EVM network (using the [Alchemy naming convention](https://github.com/alchemyplatform/alchemy-sdk-js/blob/main/docs-md/enums/Network.md)).
+  * `#Provider : nat64` The ID of the provider to be used for this call. Call `get_providers` to view a full list of providers.
 * `json_rpc_payload`: The payload for the JSON-RPC request. View examples in the [Ethereum documentation](https://ethereum.org/en/developers/docs/apis/json-rpc/).
 * `max_response_bytes`: The expected maximum size of the response of the Web2 API server. This parameter determines the network response size that is charged for. Not specifying it or it being larger than required may lead to substantial extra cycles cost for the HTTPS outcalls mechanism as its (large) default value is used and charged for.
 * `EthRpcResult`: The response comprises the JSON-encoded result or error, see the corresponding type.
 
 
-### `provider_request`
-
-Make a request to a Web2 Ethereum node using a registered provider for a JSON-RPC service. There is no need for the client to have any established relationship with the API service.
-
-    provider_request: (provider_id: nat64, json_rpc_payload: text, max_response_bytes: nat64) -> (EthRpcResult);
-
-* `provider_id`: The id of the registered provider to be used for this call. This uniquely identifies a provider registered with the canister.
-* `json_rpc_payload`: See `request`.
-* `max_response_bytes`: See `request`.
-* `EthRpcResult`: See `request`.
-
 ### `request_cost`
 
 Calculate the cost of sending a request with the given input arguments.
 
-    request_cost: (service_url: text, json_rpc_payload: text, max_response_bytes: nat64) -> (nat) query;
+    request_cost: (source: Source, json_rpc_payload: text, max_response_bytes: nat64) -> (nat) query;
 
-* `service_url`: The URL of the service, including any API key if required for access-protected services.
+* `source`: See `request`.
 * `json_rpc_payload`: See `request`.
 * `max_response_bytes`: See `request`.
 
-
-### `provider_request_cost`
-
-Calculate the cost of sending a request with the given input arguments.
-
-    provider_request_cost: (provider_id: nat64, json_rpc_payload: text, max_response_bytes: nat64) -> (nat) query;
-
-* `provider_id`: The id of the registered provider to be used for this call. This uniquely identifies a provider registered with the canister.
-* `json_rpc_payload`: See `request_cost`.
-* `max_response_bytes`: See `request_cost`.
 
 ### `get_providers`
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 60000
 
 # Register your own provider
 dfx canister call ic_eth register_provider '(record { chain_id=1; base_url="https://cloudflare-eth.com"; credential_path="/v1/mainnet"; cycles_per_call=10; cycles_per_message_byte=1; })'
-dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Provider=0},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+
+# Use a specific EVM chain
+dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Chain=0x1},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
 
 ### Ethereum RPC (IC mainnet)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ dfx canister call ic_eth request '(variant {Url="https://cloudflare-eth.com/v1/m
 
 ## Examples
 
+### Ethereum RPC (IC mainnet)
+```bash
+dfx canister call ic_eth --network ic --wallet $(dfx identity --network ic get-wallet) --with-cycles 600000000 request '(variant {Chain=0x1},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+```
+
 ### Ethereum RPC (local replica)
 ```bash
 # Use a custom provider
@@ -63,12 +68,6 @@ dfx canister call ic_eth register_provider '(record { chain_id=1; base_url="http
 
 # Use a specific EVM chain
 dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Chain=0x1},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
-```
-
-### Ethereum RPC (IC mainnet)
-```bash
-dfx canister --network ic call ic_eth --wallet $(dfx identity --network ic get-wallet) --with-cycles 600000000 request '(variant {Url="https://cloudflare-eth.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
-dfx canister --network ic call ic_eth --wallet $(dfx identity --network ic get-wallet) --with-cycles 600000000 request '(variant {Url="https://ethereum.publicnode.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
 
 ### Authorization (local replica)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dfx start --background
 dfx deploy ic_eth
 
 # Call the `eth_gasPrice` JSON-RPC method
-dfx canister call ic_eth request '("https://cloudflare-eth.com/v1/mainnet", "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
+dfx canister call ic_eth request '(variant {Url="https://cloudflare-eth.com/v1/mainnet"}, "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}", 1000)' --wallet $(dfx identity get-wallet) --with-cycles 600000000
 ```
 
 ## Examples
@@ -55,18 +55,18 @@ dfx canister call ic_eth request '("https://cloudflare-eth.com/v1/mainnet", "{\"
 ### Ethereum RPC (local replica)
 ```bash
 # Use a custom provider
-dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '("https://cloudflare-eth.com","{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
-dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '("https://ethereum.publicnode.com","{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Url="https://cloudflare-eth.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Url="https://ethereum.publicnode.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 
 # Register your own provider
 dfx canister call ic_eth register_provider '(record { chain_id=1; base_url="https://cloudflare-eth.com"; credential_path="/v1/mainnet"; cycles_per_call=10; cycles_per_message_byte=1; })'
-dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 provider_request '(0,"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+dfx canister call ic_eth --wallet $(dfx identity get-wallet) --with-cycles 600000000 request '(variant {Provider=0},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
 
 ### Ethereum RPC (IC mainnet)
 ```bash
-dfx canister --network ic call ic_eth --wallet $(dfx identity --network ic get-wallet) --with-cycles 600000000 request '("https://cloudflare-eth.com","{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
-dfx canister --network ic call ic_eth --wallet $(dfx identity --network ic get-wallet) --with-cycles 600000000 request '("https://ethereum.publicnode.com","{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+dfx canister --network ic call ic_eth --wallet $(dfx identity --network ic get-wallet) --with-cycles 600000000 request '(variant {Url="https://cloudflare-eth.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
+dfx canister --network ic call ic_eth --wallet $(dfx identity --network ic get-wallet) --with-cycles 600000000 request '(variant {Url="https://ethereum.publicnode.com"},"{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",1000)'
 ```
 
 ### Authorization (local replica)

--- a/candid/ic_eth.did
+++ b/candid/ic_eth.did
@@ -24,6 +24,8 @@ type RegisteredProvider = record {
   cycles_per_call : nat64;
 };
 type Result = variant { Ok : vec nat8; Err : EthRpcError };
+type Result_1 = variant { Ok : nat; Err : EthRpcError };
+type Source = variant { Url : text; Network : text; Provider : nat64 };
 service : {
   authorize : (principal, Auth) -> ();
   deauthorize : (principal, Auth) -> ();
@@ -32,11 +34,9 @@ service : {
   get_open_rpc_access : () -> (bool) query;
   get_owed_cycles : (nat64) -> (nat) query;
   get_providers : () -> (vec RegisteredProvider) query;
-  provider_request : (nat64, text, nat64) -> (Result);
-  provider_request_cost : (nat64, text, nat64) -> (opt nat) query;
   register_provider : (RegisterProvider) -> (nat64);
-  request : (text, text, nat64) -> (Result);
-  request_cost : (text, text, nat64) -> (nat) query;
+  request : (Source, text, nat64) -> (Result);
+  request_cost : (Source, text, nat64) -> (Result_1) query;
   set_nodes_in_subnet : (nat32) -> ();
   set_open_rpc_access : (bool) -> ();
   unregister_provider : (nat64) -> ();

--- a/candid/ic_eth.did
+++ b/candid/ic_eth.did
@@ -7,6 +7,16 @@ type EthRpcError = variant {
   ServiceUrlHostMissing;
   ProviderNotFound;
   NoPermission;
+  ProviderNotActive;
+};
+type ProviderView = record {
+  base_url : text;
+  active : bool;
+  owner : principal;
+  provider_id : nat64;
+  cycles_per_message_byte : nat64;
+  chain_id : nat64;
+  cycles_per_call : nat64;
 };
 type RegisterProvider = record {
   base_url : text;
@@ -15,17 +25,17 @@ type RegisterProvider = record {
   cycles_per_call : nat64;
   credential_path : text;
 };
-type RegisteredProvider = record {
-  base_url : text;
-  owner : principal;
-  provider_id : nat64;
-  cycles_per_message_byte : nat64;
-  chain_id : nat64;
-  cycles_per_call : nat64;
-};
 type Result = variant { Ok : vec nat8; Err : EthRpcError };
 type Result_1 = variant { Ok : nat; Err : EthRpcError };
-type Source = variant { Url : text; Network : text; Provider : nat64 };
+type Source = variant { Url : text; Chain : nat64; Provider : nat64 };
+type UpdateProvider = record {
+  base_url : opt text;
+  active : opt bool;
+  provider_id : nat64;
+  cycles_per_message_byte : opt nat64;
+  cycles_per_call : opt nat64;
+  credential_path : opt text;
+};
 service : {
   authorize : (principal, Auth) -> ();
   deauthorize : (principal, Auth) -> ();
@@ -33,14 +43,14 @@ service : {
   get_nodes_in_subnet : () -> (nat32) query;
   get_open_rpc_access : () -> (bool) query;
   get_owed_cycles : (nat64) -> (nat) query;
-  get_providers : () -> (vec RegisteredProvider) query;
+  get_providers : () -> (vec ProviderView) query;
   register_provider : (RegisterProvider) -> (nat64);
   request : (Source, text, nat64) -> (Result);
   request_cost : (Source, text, nat64) -> (Result_1) query;
   set_nodes_in_subnet : (nat32) -> ();
   set_open_rpc_access : (bool) -> ();
   unregister_provider : (nat64) -> ();
-  update_provider_credential : (nat64, text) -> ();
+  update_provider : (UpdateProvider) -> ();
   verify_signature : (vec nat8, vec nat8, vec nat8) -> (bool) query;
   withdraw_owed_cycles : (nat64, principal) -> ();
 }

--- a/scripts/local
+++ b/scripts/local
@@ -8,8 +8,8 @@ dfx canister call ic_eth authorize "(principal \"$PRINCIPAL\", variant { Registe
 
 dfx canister call ic_eth register_provider '(record {base_url = "https://cloudflare-eth.com"; credential_path = "/v1/mainnet"; chain_id = 1; cycles_per_call = 1000; cycles_per_message_byte = 100})'
 
-dfx canister call ic_eth request_cost '("https://cloudflare-eth.com", "{ \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x2244\", true], \"id\": 1 }", 1000)'
-dfx canister call ic_eth request '("https://cloudflare-eth.com", "{ \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x2244\", true], \"id\": 1 }", 1000)'
+dfx canister call ic_eth request_cost '(variant {Chain=1}, "{ \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x2244\", true], \"id\": 1 }", 1000)'
+dfx canister call ic_eth request '(variant {Chain=1}, "{ \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x2244\", true], \"id\": 1 }", 1000)'
 
-dfx canister call ic_eth provider_request_cost '(0, "{ \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x2244\", true], \"id\": 1 }", 1000)'
-dfx canister call ic_eth provider_request '(0, "{ \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x2244\", true], \"id\": 1 }", 1000)'
+dfx canister call ic_eth request_cost '(variant {Provider=0}, "{ \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x2244\", true], \"id\": 1 }", 1000)'
+dfx canister call ic_eth request '(variant {Provider=0}, "{ \"jsonrpc\": \"2.0\", \"method\": \"eth_getBlockByNumber\", \"params\": [\"0x2244\", true], \"id\": 1 }", 1000)'

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -1,9 +1,36 @@
 use crate::*;
 
-/// Calculate the baseline cost of sending a JSON-RPC request using HTTP outcalls.
 pub fn get_request_cost(
+    source: &ResolvedSource,
     json_rpc_payload: &str,
+    max_response_bytes: u64,
+) -> u128 {
+    let (http_cost, provider_cost) =
+        get_request_costs(source, json_rpc_payload, max_response_bytes);
+    http_cost + provider_cost
+}
+
+pub fn get_request_costs(
+    source: &ResolvedSource,
+    json_rpc_payload: &str,
+    max_response_bytes: u64,
+) -> (u128, u128) {
+    match source {
+        ResolvedSource::Url(s) => (
+            get_http_request_cost(s, json_rpc_payload, max_response_bytes),
+            0,
+        ),
+        ResolvedSource::Provider(p) => (
+            get_http_request_cost(&p.service_url(), json_rpc_payload, max_response_bytes),
+            get_provider_cost(p, json_rpc_payload),
+        ),
+    }
+}
+
+/// Calculate the baseline cost of sending a JSON-RPC request using HTTP outcalls.
+pub fn get_http_request_cost(
     service_url: &str,
+    json_rpc_payload: &str,
     max_response_bytes: u64,
 ) -> u128 {
     let nodes_in_subnet = METADATA.with(|m| m.borrow().get().nodes_in_subnet);
@@ -17,7 +44,7 @@ pub fn get_request_cost(
 }
 
 /// Calculate the additional cost for calling a registered JSON-RPC provider.
-pub fn get_provider_cost(json_rpc_payload: &str, provider: &Provider) -> u128 {
+pub fn get_provider_cost(provider: &Provider, json_rpc_payload: &str) -> u128 {
     let nodes_in_subnet = METADATA.with(|m| m.borrow().get().nodes_in_subnet);
     let cost_per_node = provider.cycles_per_call as u128
         + provider.cycles_per_message_byte as u128 * json_rpc_payload.len() as u128;
@@ -33,15 +60,15 @@ fn test_request_cost() {
     });
 
     let base_cost = get_request_cost(
+        &ResolvedSource::Url("https://cloudflare-eth.com".to_string()),
         "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",
-        "https://cloudflare-eth.com",
         1000,
     );
     let s10 = "0123456789";
     let base_cost_s10 = get_request_cost(
+        &ResolvedSource::Url("https://cloudflare-eth.com".to_string()),
         &("{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}".to_string()
             + s10),
-        "https://cloudflare-eth.com",
         1000,
     );
     assert_eq!(
@@ -69,8 +96,8 @@ fn test_provider_cost() {
         cycles_per_message_byte: 2,
     };
     let base_cost = get_provider_cost(
-        "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",
         &provider,
+        "{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}",
     );
 
     let provider_s10 = Provider {
@@ -85,9 +112,9 @@ fn test_provider_cost() {
     };
     let s10 = "0123456789";
     let base_cost_s10 = get_provider_cost(
+        &provider_s10,
         &("{\"jsonrpc\":\"2.0\",\"method\":\"eth_gasPrice\",\"params\":[],\"id\":1}".to_string()
             + s10),
-        &provider_s10,
     );
     assert_eq!(base_cost + (10 * 2 + 1000) * 13, base_cost_s10)
 }

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -94,6 +94,7 @@ fn test_provider_cost() {
         cycles_owed: 0,
         cycles_per_call: 0,
         cycles_per_message_byte: 2,
+        active: true,
     };
     let base_cost = get_provider_cost(
         &provider,
@@ -109,6 +110,7 @@ fn test_provider_cost() {
         cycles_owed: 0,
         cycles_per_call: 1000,
         cycles_per_message_byte: 2,
+        active: true,
     };
     let s10 = "0123456789";
     let base_cost_s10 = get_provider_cost(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -42,10 +42,3 @@ pub const INITIAL_SERVICE_HOSTS_ALLOWLIST: &[&str] = &[
 // Principals allowed to send JSON-RPC requests.
 pub const DEFAULT_NODES_IN_SUBNET: u32 = 13;
 pub const DEFAULT_OPEN_RPC_ACCESS: bool = true;
-pub const RPC_ALLOWLIST: &[&str] = &[];
-// Principals allowed to registry API keys.
-pub const REGISTER_PROVIDER_ALLOWLIST: &[&str] = &[];
-// Principals that will not be charged cycles to send JSON-RPC requests.
-pub const FREE_RPC_ALLOWLIST: &[&str] = &[];
-// Principals who have Admin authorization.
-pub const AUTHORIZED_ADMIN: &[&str] = &[];

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,23 +39,6 @@ fn request_cost(
     ))
 }
 
-// #[query]
-// #[candid_method(query)]
-// fn provider_request_cost(
-//     provider_id: u64,
-//     json_rpc_payload: String,
-//     max_response_bytes: u64,
-// ) -> Option<u128> {
-//     let provider = PROVIDERS.with(|p| p.borrow().get(&provider_id))?;
-//     let request_cost = get_request_cost(
-//         &json_rpc_payload,
-//         &provider.service_url(),
-//         max_response_bytes,
-//     );
-//     let provider_cost = get_provider_cost(&json_rpc_payload, &provider);
-//     Some(request_cost + provider_cost)
-// }
-
 #[query]
 #[candid_method(query)]
 fn get_providers() -> Vec<ProviderView> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn register_provider(provider: RegisterProvider) -> u64 {
                 cycles_per_call: provider.cycles_per_call,
                 cycles_per_message_byte: provider.cycles_per_message_byte,
                 cycles_owed: 0,
-                active: false,
+                active: true,
             },
         )
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,10 @@ fn update_provider(update: UpdateProvider) {
             if provider.owner != ic_cdk::caller() && !is_authorized(Auth::Admin) {
                 ic_cdk::trap("Provider owner != caller");
             }
+            if let Some(url) = update.base_url {
+                validate_base_url(&url);
+                provider.base_url = url;
+            }
             if let Some(path) = update.credential_path {
                 validate_credential_path(&path);
                 provider.credential_path = path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,11 @@ pub fn verify_signature(eth_address: Vec<u8>, message: Vec<u8>, signature: Vec<u
 #[update]
 #[candid_method]
 async fn request(
-    service_url: String,
+    source: Source,
     json_rpc_payload: String,
     max_response_bytes: u64,
 ) -> Result<Vec<u8>, EthRpcError> {
+    
     do_http_request(
         ResolvedSource::Url(service_url),
         &json_rpc_payload,

--- a/src/types.rs
+++ b/src/types.rs
@@ -134,6 +134,7 @@ pub struct RegisterProvider {
 #[derive(Debug, CandidType, Deserialize)]
 pub struct UpdateProvider {
     pub provider_id: u64,
+    pub base_url: Option<String>,
     pub credential_path: Option<String>,
     pub cycles_per_call: Option<u64>,
     pub cycles_per_message_byte: Option<u64>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,13 +15,18 @@ pub enum Source {
 }
 
 impl Source {
-    pub fn resolve(self) -> Option<ResolvedSource> {
-        Some(match self {
+    pub fn resolve(self) -> Result<ResolvedSource, EthRpcError> {
+        Ok(match self {
             Source::Url(name) => ResolvedSource::Url(name),
             Source::Provider(id) => ResolvedSource::Provider(
                 PROVIDERS
-                    .with(|providers| providers.borrow().get(&id))?
-                    .to_owned(),
+                    .with(|providers| {
+                        providers
+                            .borrow()
+                            .get(&id)
+                            .ok_or(EthRpcError::ProviderNotFound)
+                    })?
+                    .clone(),
             ),
             Source::Network(_network) => unimplemented!(), //////
         })

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,28 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use crate::constants::STRING_STORABLE_MAX_SIZE;
+use crate::PROVIDERS;
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub enum Source {
+    Url(String),
+    Provider(u64),
+    Network(String),
+}
+
+impl Source {
+    pub fn resolve(self) -> Option<ResolvedSource> {
+        Some(match self {
+            Source::Url(name) => ResolvedSource::Url(name),
+            Source::Provider(id) => ResolvedSource::Provider(
+                PROVIDERS
+                    .with(|providers| providers.borrow().get(&id))?
+                    .to_owned(),
+            ),
+            Source::Network(_network) => unimplemented!(), //////
+        })
+    }
+}
 
 pub enum ResolvedSource {
     Url(String),

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,7 +28,7 @@ impl Source {
                 if !p.active {
                     Err(EthRpcError::ProviderNotActive)?
                 } else {
-                    p.clone()
+                    p
                 }
             }),
             Source::Chain(id) => ResolvedSource::Provider(PROVIDERS.with(|p| {


### PR DESCRIPTION
This PR changes the `request` and `request_cost` methods to receive `Source` variants which can represent URLs, registered providers, or [EVM chain identifiers](https://chainlist.org/?testnets=true). This provides a layer of abstraction for more realistic use cases where the developer wants to call an RPC method on a specific EVM network without needing to know which specific RPC provider is being used behind the scenes. 

At the moment, the "preferred provider" for a given network is defined as the earliest registered provider with the `active` flag set to `true`. 