### PR TITLE
Refactor `active` to `primary` in RPC providers

### DIFF
--- a/API.md
+++ b/API.md
@@ -74,6 +74,7 @@ get_providers: () -> (vec RegisteredProvider) query;
 * `service _url`: See `RegisterProvider`.
 * `cycles_per_call`: See `RegisterProvider`.
 * `cycles_per_message_byte`: See `RegisterProvider`.
+* `primary`: A flag indicating that an RPC provider is a good default compared to others with the same chain id.
 
 Clients of this canister need to select a provider that matches w.r.t. the `chain_id` the network they intend to connect to. If multiple providers are available for a given `chain_id`, the per-message or per-byte price or the entity behind the provider (this can be inferred from the `base_url`) may be factors to choose a suitable provider.
 

--- a/API.md
+++ b/API.md
@@ -60,6 +60,7 @@ type RegisteredProvider = record {
     base_url: text;
     cycles_per_call: nat64;
     cycles_per_message_byte: nat64;
+    primary: bool;
 };
 
 get_providers: () -> (vec RegisteredProvider) query;

--- a/API.md
+++ b/API.md
@@ -74,7 +74,7 @@ get_providers: () -> (vec RegisteredProvider) query;
 * `service _url`: See `RegisterProvider`.
 * `cycles_per_call`: See `RegisterProvider`.
 * `cycles_per_message_byte`: See `RegisterProvider`.
-* `primary`: A flag indicating that an RPC provider is a good default compared to others with the same chain id.
+* `primary`: Indicates whether the RPC provider is a good default compared to others with the same `chain_id`.
 
 Clients of this canister need to select a provider that matches w.r.t. the `chain_id` the network they intend to connect to. If multiple providers are available for a given `chain_id`, the per-message or per-byte price or the entity behind the provider (this can be inferred from the `base_url`) may be factors to choose a suitable provider.
 

--- a/candid/ic_eth.did
+++ b/candid/ic_eth.did
@@ -7,14 +7,13 @@ type EthRpcError = variant {
   ServiceUrlHostMissing;
   ProviderNotFound;
   NoPermission;
-  ProviderNotActive;
 };
 type ProviderView = record {
   base_url : text;
-  active : bool;
   owner : principal;
   provider_id : nat64;
   cycles_per_message_byte : nat64;
+  primary : bool;
   chain_id : nat64;
   cycles_per_call : nat64;
 };
@@ -30,9 +29,9 @@ type Result_1 = variant { Ok : nat; Err : EthRpcError };
 type Source = variant { Url : text; Chain : nat64; Provider : nat64 };
 type UpdateProvider = record {
   base_url : opt text;
-  active : opt bool;
   provider_id : nat64;
   cycles_per_message_byte : opt nat64;
+  primary : opt bool;
   cycles_per_call : opt nat64;
   credential_path : opt text;
 };

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -94,7 +94,7 @@ fn test_provider_cost() {
         cycles_owed: 0,
         cycles_per_call: 0,
         cycles_per_message_byte: 2,
-        active: true,
+        primary: false,
     };
     let base_cost = get_provider_cost(
         &provider,
@@ -110,7 +110,7 @@ fn test_provider_cost() {
         cycles_owed: 0,
         cycles_per_call: 1000,
         cycles_per_message_byte: 2,
-        active: true,
+        primary: false,
     };
     let s10 = "0123456789";
     let base_cost_s10 = get_provider_cost(

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,12 @@ fn register_provider(provider: RegisterProvider) -> u64 {
 fn update_provider(update: UpdateProvider) {
     PROVIDERS.with(|p| match p.borrow_mut().get(&update.provider_id) {
         Some(mut provider) => {
-            if provider.owner != ic_cdk::caller() && !is_authorized(Auth::Admin) {
-                ic_cdk::trap("Provider owner != caller");
+            let is_admin = is_authorized(Auth::Admin);
+            // if provider.owner != ic_cdk::caller() && !is_admin {
+            //     ic_cdk::trap("Provider owner != caller");
+            // }
+            if !is_admin {
+                ic_cdk::trap("`update_provider` currently requires admin permissions")
             }
             if let Some(url) = update.base_url {
                 validate_base_url(&url);

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn get_providers() -> Vec<ProviderView> {
                 base_url: e.base_url,
                 cycles_per_call: e.cycles_per_call,
                 cycles_per_message_byte: e.cycles_per_message_byte,
-                active: e.active,
+                primary: e.primary,
             })
             .collect::<Vec<ProviderView>>()
     })
@@ -83,7 +83,7 @@ fn register_provider(provider: RegisterProvider) -> u64 {
                 cycles_per_call: provider.cycles_per_call,
                 cycles_per_message_byte: provider.cycles_per_message_byte,
                 cycles_owed: 0,
-                active: true,
+                primary: false,
             },
         )
     });
@@ -106,8 +106,8 @@ fn update_provider(update: UpdateProvider) {
                 validate_credential_path(&path);
                 provider.credential_path = path;
             }
-            if let Some(active) = update.active {
-                provider.active = active;
+            if let Some(primary) = update.primary {
+                provider.primary = primary;
             }
             if let Some(cycles_per_call) = update.cycles_per_call {
                 provider.cycles_per_call = cycles_per_call;


### PR DESCRIPTION
This PR makes it possible for administrators to change the default canister for the `Chain` source variant by enabling the `primary` flag via `update_provider`. This will be important for gradually deprecating RPC providers when necessary in production. 