### PR TITLE
Add `Service` source variant

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,10 +28,11 @@ Make a request to a Web2 Ethereum node using the caller's URL to an openly avail
 
     request: (source: Source, json_rpc_payload: text, max_response_bytes: nat64) -> (Result<blob, EthRpcError>);
 
-* `source`: Any of the following:
-  * `#Url : text` The URL of the service, including any API key if required for access-protected services.
-  * `#Chain : nat64` The relevant EVM network identifier ([reference list](https://chainlist.org/?testnets=true)).
-  * `#Provider : nat64` The ID of the provider to be used for this call. Call `get_providers` to view a full list of providers.
+* `source`: Any of the following enum variants:
+  * `Chain: nat64` The relevant EVM network identifier ([reference list](https://chainlist.org/?testnets=true)).
+  * `Service: { hostname: text, chain_id: opt nat64 }` A specific RPC service with the given hostname (e.g. `cloudflare-eth.com`) and optional chain id (`0x1` for Ethereum mainnet).
+  * `Provider: nat64` The ID of the provider to be used for this call. Call `get_providers` to view a full list of providers.
+  * `Url: text` The URL of the service, including any API key if required for access-protected services. It's only recommended to use this if no registered RPC provider exists for a given EVM network.
 * `json_rpc_payload`: The payload for the JSON-RPC request. View examples in the [Ethereum documentation](https://ethereum.org/en/developers/docs/apis/json-rpc/).
 * `max_response_bytes`: The expected maximum size of the response of the Web2 API server. This parameter determines the network response size that is charged for. Not specifying it or it being larger than required may lead to substantial extra cycles cost for the HTTPS outcalls mechanism as its (large) default value is used and charged for.
 

--- a/API.md
+++ b/API.md
@@ -76,7 +76,7 @@ get_providers: () -> (vec RegisteredProvider) query;
 * `cycles_per_message_byte`: See `RegisterProvider`.
 * `primary`: Indicates whether the RPC provider is a good default compared to others with the same `chain_id`.
 
-Clients of this canister need to select a provider that matches w.r.t. the `chain_id` the network they intend to connect to. If multiple providers are available for a given `chain_id`, the per-message or per-byte price or the entity behind the provider (this can be inferred from the `base_url`) may be factors to choose a suitable provider.
+Clients of this canister need to select a provider that matches w.r.t. the `chain_id` the network they intend to connect to. If multiple providers are available for a given `chain_id`, the per-message or per-byte price or the entity behind the RPC service (which can be inferred from the `hostname`) may be factors to choose a suitable provider.
 
 
 ### `register_provider`

--- a/API.md
+++ b/API.md
@@ -57,7 +57,7 @@ type RegisteredProvider = record {
     provider_id: nat64;
     owner: principal;
     chain_id: nat64;
-    base_url: text;
+    hostname: text;
     cycles_per_call: nat64;
     cycles_per_message_byte: nat64;
     primary: bool;
@@ -86,7 +86,7 @@ Register a new provider for a Web2-based service.
 ```candid
 type RegisterProvider = record {
     chain_id: nat64;
-    base_url: text;
+    hostname: text;
     credential_path: text;
     cycles_per_call: nat64;
     cycles_per_message_byte: nat64;
@@ -97,8 +97,8 @@ register_provider: (RegisterProvider) -> ();
 
 The `RegisterProvider` record defines the details about the service to register, including the API key for the service.
 * `chain_id`: The id of the Ethereum chain this provider allows to connect to. The ids refer to the chain ids as defined for EVM-compatible blockchains, see, e.g., [ChainList](https://chainlist.org/?testnets=true).
-* `base_url`: The URLs of the Web2 service provider that is used by the canister when using this provider.
-* `credential_path`: A path containing API key for authorizing requests to this service provider. This part of the path is private to the entity registering it and the canister. It is not exposed in the response of the `get_providers` method. The URL used to access the service is constructed by concatenating the `base_url` and the `credential_path` (without a separator), e.g., `"https://cloudflare-eth.com"` and `"/my-api-key"`.
+* `hostname`: The URL host of the Web2 service provider that is used by the canister when using this provider.
+* `credential_path`: A path containing API key for authorizing requests to this service provider. This part of the path is private to the entity registering it and the canister. It is not exposed in the response of the `get_providers` method. The URL used to access the service is constructed by concatenating `hostname` and `credential_path` without a separator, e.g., `"cloudflare-eth.com"` and `"/v1/mainnet/my_api_key"` resolves to `https://cloudflare-eth.com/v1/mainnet/my_api_key`.
 * `cycles_per_call`: Cycles charged per call by the canister in addition to the base charges when using this provider.
 * `cycles_per_message_byte`: Cycles charged per payload byte by the canister in addition to the base charges when using this provider.
 

--- a/candid/ic_eth.did
+++ b/candid/ic_eth.did
@@ -26,7 +26,12 @@ type RegisterProvider = record {
 };
 type Result = variant { Ok : vec nat8; Err : EthRpcError };
 type Result_1 = variant { Ok : nat; Err : EthRpcError };
-type Source = variant { Url : text; Chain : nat64; Provider : nat64 };
+type Source = variant {
+  Url : text;
+  Service : record { base_url : text; chain_id : opt nat64 };
+  Chain : nat64;
+  Provider : nat64;
+};
 type UpdateProvider = record {
   base_url : opt text;
   provider_id : nat64;

--- a/candid/ic_eth.did
+++ b/candid/ic_eth.did
@@ -9,8 +9,8 @@ type EthRpcError = variant {
   NoPermission;
 };
 type ProviderView = record {
-  base_url : text;
   owner : principal;
+  hostname : text;
   provider_id : nat64;
   cycles_per_message_byte : nat64;
   primary : bool;
@@ -18,7 +18,7 @@ type ProviderView = record {
   cycles_per_call : nat64;
 };
 type RegisterProvider = record {
-  base_url : text;
+  hostname : text;
   cycles_per_message_byte : nat64;
   chain_id : nat64;
   cycles_per_call : nat64;
@@ -28,12 +28,12 @@ type Result = variant { Ok : vec nat8; Err : EthRpcError };
 type Result_1 = variant { Ok : nat; Err : EthRpcError };
 type Source = variant {
   Url : text;
-  Service : record { base_url : text; chain_id : opt nat64 };
+  Service : record { hostname : text; chain_id : opt nat64 };
   Chain : nat64;
   Provider : nat64;
 };
 type UpdateProvider = record {
-  base_url : opt text;
+  hostname : opt text;
   provider_id : nat64;
   cycles_per_message_byte : opt nat64;
   primary : opt bool;

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -87,7 +87,7 @@ fn test_provider_cost() {
 
     let provider = Provider {
         provider_id: 0,
-        base_url: "".to_string(),
+        hostname: "".to_string(),
         credential_path: "".to_string(),
         owner: Principal::anonymous(),
         chain_id: 1,
@@ -103,7 +103,7 @@ fn test_provider_cost() {
 
     let provider_s10 = Provider {
         provider_id: 0,
-        base_url: "".to_string(),
+        hostname: "".to_string(),
         credential_path: "".to_string(),
         owner: Principal::anonymous(),
         chain_id: 1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn get_providers() -> Vec<ProviderView> {
                 provider_id: e.provider_id,
                 owner: e.owner,
                 chain_id: e.chain_id,
-                base_url: e.base_url,
+                hostname: e.hostname,
                 cycles_per_call: e.cycles_per_call,
                 cycles_per_message_byte: e.cycles_per_message_byte,
                 primary: e.primary,

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -4,21 +4,21 @@ pub fn get_default_providers() -> Vec<RegisterProvider> {
     vec![
         RegisterProvider {
             chain_id: 0x1, // Ethereum mainnet
-            base_url: "https://cloudflare-eth.com".to_string(),
+            hostname: "cloudflare-eth.com".to_string(),
             credential_path: "/v1/mainnet".to_string(),
             cycles_per_call: 0,
             cycles_per_message_byte: 0,
         },
         RegisterProvider {
             chain_id: 0x5, // Goerli testnet
-            base_url: "https://ethereum-goerli.publicnode.com".to_string(),
+            hostname: "ethereum-goerli.publicnode.com".to_string(),
             credential_path: "".to_string(),
             cycles_per_call: 0,
             cycles_per_message_byte: 0,
         },
         RegisterProvider {
             chain_id: 0xaa36a7, // Sepolia testnet
-            base_url: "https://rpc.sepolia.org".to_string(),
+            hostname: "rpc.sepolia.org".to_string(),
             credential_path: "".to_string(),
             cycles_per_call: 0,
             cycles_per_message_byte: 0,
@@ -27,9 +27,7 @@ pub fn get_default_providers() -> Vec<RegisterProvider> {
 }
 
 pub fn do_register_provider(caller: Principal, provider: RegisterProvider) -> u64 {
-    let parsed_url = url::Url::parse(&provider.base_url).expect("unable to parse service_url");
-    let host = parsed_url.host_str().expect("service_url host missing");
-    validate_base_url(host);
+    validate_hostname(&provider.hostname);
     validate_credential_path(&provider.credential_path);
     let provider_id = METADATA.with(|m| {
         let mut metadata = m.borrow().get().clone();
@@ -44,7 +42,7 @@ pub fn do_register_provider(caller: Principal, provider: RegisterProvider) -> u6
                 provider_id,
                 owner: caller,
                 chain_id: provider.chain_id,
-                base_url: provider.base_url,
+                hostname: provider.hostname,
                 credential_path: provider.credential_path,
                 cycles_per_call: provider.cycles_per_call,
                 cycles_per_message_byte: provider.cycles_per_message_byte,
@@ -77,9 +75,9 @@ pub fn do_update_provider(caller: Principal, update: UpdateProvider) {
                 if provider.owner != caller && !is_authorized(Auth::Admin) {
                     ic_cdk::trap("Provider owner != caller");
                 }
-                if let Some(url) = update.base_url {
-                    validate_base_url(&url);
-                    provider.base_url = url;
+                if let Some(hostname) = update.hostname {
+                    validate_hostname(&hostname);
+                    provider.hostname = hostname;
                 }
                 if let Some(path) = update.credential_path {
                     validate_credential_path(&path);

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ pub enum Source {
     Provider(u64),
     Chain(u64),
     Service {
-        base_url: String,
+        hostname: String,
         chain_id: Option<u64>,
     },
 }
@@ -39,10 +39,10 @@ impl Source {
                     .ok_or(EthRpcError::ProviderNotFound)?
                     .1)
             })?),
-            Source::Service { base_url, chain_id } => {
+            Source::Service { hostname, chain_id } => {
                 ResolvedSource::Provider(PROVIDERS.with(|providers| {
                     let matches_provider = |p: &Provider| {
-                        p.base_url == base_url
+                        p.hostname == hostname
                             && match chain_id {
                                 Some(id) => p.chain_id == id,
                                 None => true,
@@ -135,7 +135,7 @@ pub struct ProviderView {
     pub provider_id: u64,
     pub owner: Principal,
     pub chain_id: u64,
-    pub base_url: String,
+    pub hostname: String,
     pub cycles_per_call: u64,
     pub cycles_per_message_byte: u64,
     pub primary: bool,
@@ -144,7 +144,7 @@ pub struct ProviderView {
 #[derive(Debug, CandidType, Deserialize)]
 pub struct RegisterProvider {
     pub chain_id: u64,
-    pub base_url: String,
+    pub hostname: String,
     pub credential_path: String,
     pub cycles_per_call: u64,
     pub cycles_per_message_byte: u64,
@@ -153,7 +153,7 @@ pub struct RegisterProvider {
 #[derive(Debug, CandidType, Deserialize)]
 pub struct UpdateProvider {
     pub provider_id: u64,
-    pub base_url: Option<String>,
+    pub hostname: Option<String>,
     pub credential_path: Option<String>,
     pub cycles_per_call: Option<u64>,
     pub cycles_per_message_byte: Option<u64>,
@@ -165,7 +165,7 @@ pub struct Provider {
     pub provider_id: u64,
     pub owner: Principal,
     pub chain_id: u64,
-    pub base_url: String,
+    pub hostname: String,
     pub credential_path: String,
     pub cycles_per_call: u64,
     pub cycles_per_message_byte: u64,
@@ -175,7 +175,7 @@ pub struct Provider {
 
 impl Provider {
     pub fn service_url(&self) -> String {
-        format!("{}{}", self.base_url, self.credential_path)
+        format!("https://{}{}", self.hostname, self.credential_path)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -51,8 +51,8 @@ impl Source {
                     let providers = providers.borrow();
                     Ok(providers
                         .iter()
-                        .find(|(_, p)| p.primary && matches_provider(&p))
-                        .or_else(|| providers.iter().find(|(_, p)| matches_provider(&p)))
+                        .find(|(_, p)| p.primary && matches_provider(p))
+                        .or_else(|| providers.iter().find(|(_, p)| matches_provider(p)))
                         .ok_or(EthRpcError::ProviderNotFound)?
                         .1)
                 })?)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,8 +1,8 @@
 use crate::*;
 
-pub fn validate_base_url(base_url: &str) {
-    if SERVICE_HOSTS_ALLOWLIST.with(|a| !a.borrow().contains(&base_url)) {
-        ic_cdk::trap("base_url host not allowed");
+pub fn validate_hostname(hostname: &str) {
+    if SERVICE_HOSTS_ALLOWLIST.with(|a| !a.borrow().contains(&hostname)) {
+        ic_cdk::trap("hostname not allowed");
     }
 }
 


### PR DESCRIPTION
Includes `#Service : {base_url : text, chain_id : opt nat64}` as an alternative to `#Provider : nat64` for the `request` and `request_cost` methods.