### PR TITLE
Enhance `TooFewCycles` error

### DIFF
--- a/candid/ic_eth.did
+++ b/candid/ic_eth.did
@@ -2,7 +2,7 @@ type Auth = variant { Rpc; RegisterProvider; FreeRpc; Admin };
 type EthRpcError = variant {
   ServiceUrlHostNotAllowed;
   HttpRequestError : record { code : nat32; message : text };
-  TooFewCycles : text;
+  TooFewCycles : record { expected : nat; received : nat };
   ServiceUrlParseError;
   ServiceUrlHostMissing;
   ProviderNotFound;

--- a/src/http.rs
+++ b/src/http.rs
@@ -34,9 +34,10 @@ pub async fn do_http_request(
     }
     if !is_authorized(Auth::FreeRpc) {
         if cycles_available < cost {
-            return Err(EthRpcError::TooFewCycles(format!(
-                "requires {cost} cycles, got {cycles_available} cycles",
-            )));
+            return Err(EthRpcError::TooFewCycles {
+                expected: cost,
+                received: cycles_available,
+            });
         }
         ic_cdk::api::call::msg_cycles_accept128(cost);
         if let Some(mut provider) = provider {

--- a/src/types.rs
+++ b/src/types.rs
@@ -205,7 +205,7 @@ impl BoundedStorable for Provider {
 #[derive(CandidType, Debug)]
 pub enum EthRpcError {
     NoPermission,
-    TooFewCycles(String),
+    TooFewCycles { expected: u128, received: u128 },
     ServiceUrlParseError,
     ServiceUrlHostMissing,
     ServiceUrlHostNotAllowed,


### PR DESCRIPTION
Passes the number of `expected` and `received` cycles in the `TooFewCycles` error variant. 