### PR TITLE
Set up IC state machine tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
+      - name: Install system dependencies
+        run: apt-get install protobuf-compiler
       - run: rustup component add clippy
       - name: Cargo clippy
         # We run clippy twice (once without tests), so that it accurately reports dead code in the non-test configuration.
@@ -86,6 +88,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - name: Install system dependencies
+        run: apt-get install protobuf-compiler
+
       - name: Cargo build
         uses: actions-rs/cargo@master
         with:
@@ -98,6 +103,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
+
+
+      - name: Install system dependencies
+        run: apt-get install protobuf-compiler
 
       - name: Cargo test
         uses: actions-rs/cargo@master
@@ -121,6 +130,9 @@ jobs:
         uses: actions/checkout@master
 
       - uses: Swatinem/rust-cache@v2
+
+      - name: Install system dependencies
+        run: apt-get install protobuf-compiler
 
       - name: Install dfx
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         # `manual_range_contains` is disabled because a >= x && a < y reads more clearly than (x..y).contains(a) and
         # there are additional caveats for floating point numbers (https://github.com/rust-lang/rust-clippy/issues/6455)
         run: |
-          cargo clippy -- -D clippy::all -D warnings -A clippy::manual_range_contains --target wasm32-unknown-unknown
-          cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains --target wasm32-unknown-unknown
+          cargo clippy -- -D clippy::all -D warnings -A clippy::manual_range_contains
+          cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains
 
   cargo-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
 
@@ -34,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,118 +10,38 @@ on:
     paths-ignore:
       - "README.md"
 jobs:
-  # cargo-fmt:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@master
-  #     - name: Cargo fmt
-  #       run: |
-  #         rustup component add rustfmt
-  #         cargo fmt --all -- --check
-
   cargo-clippy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@master
-      - name: Install system dependencies
-        run: apt-get install protobuf-compiler
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+
       - run: rustup component add clippy
+
       - name: Cargo clippy
         # We run clippy twice (once without tests), so that it accurately reports dead code in the non-test configuration.
         # `manual_range_contains` is disabled because a >= x && a < y reads more clearly than (x..y).contains(a) and
         # there are additional caveats for floating point numbers (https://github.com/rust-lang/rust-clippy/issues/6455)
         run: |
-          cargo clippy -- -D clippy::all -D warnings -A clippy::manual_range_contains
-          cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains
-
-  # cargo-deny:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@master
-  #     - run: cargo install --locked cargo-deny
-  #     - name: Cargo deny
-  #       run: |
-  #         cargo-deny check --hide-inclusion-graph || true
-
-  # cargo-audit:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@master
-  #     - run: cargo install --locked cargo-audit
-  #     - name: Cargo audit
-  #       run: |
-  #         cargo audit || true
-
-  # cargo-check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@master
-
-  #     - name: Cargo build
-  #       uses: actions-rs/cargo@master
-  #       with:
-  #         command: check
-  #         args: --all-targets
-
-  # cargo-build:
-  #   runs-on: ubuntu-latest
-  #   # needs: cargo-check
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@master
-
-  #     - name: Cargo build
-  #       uses: actions-rs/cargo@master
-  #       with:
-  #         command: build
-  #         args: --tests --release
-
-  cargo-wasm-build:
-    runs-on: ubuntu-latest
-    # needs: cargo-check
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-
-      - name: Install system dependencies
-        run: apt-get install protobuf-compiler
-
-      - name: Cargo build
-        uses: actions-rs/cargo@master
-        with:
-          command: build
-          args: --tests --release --target wasm32-unknown-unknown
+          cargo clippy -- -D clippy::all -D warnings -A clippy::manual_range_contains --target wasm32-unknown-unknown
+          cargo clippy --tests --benches -- -D clippy::all -D warnings -A clippy::manual_range_contains --target wasm32-unknown-unknown
 
   cargo-test:
     runs-on: ubuntu-latest
-    # needs: cargo-check
     steps:
       - name: Checkout
         uses: actions/checkout@master
 
-
-      - name: Install system dependencies
-        run: apt-get install protobuf-compiler
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
 
       - name: Cargo test
         uses: actions-rs/cargo@master
         with:
           command: test
-
-  # candid-check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@master
-  #     - name: Check interface
-  #       run: |
-  #         cargo run > candid/evm_rpc_expected.did
-  #         diff candid/evm_rpc.did candid/evm_rpc_expected.did
 
   e2e:
     runs-on: ubuntu-latest
@@ -131,9 +51,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install system dependencies
-        run: apt-get install protobuf-compiler
-
       - name: Install dfx
         run: |
           wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
@@ -141,7 +58,7 @@ jobs:
           rm install-dfx.sh
           dfx cache install
           echo "$HOME/bin" >> $GITHUB_PATH
-      
+
       - name: Start dfx
         run: dfx start --background
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,7 @@ jobs:
         uses: arduino/setup-protoc@v2
 
       - name: Cargo test
-        uses: actions-rs/cargo@master
-        with:
-          command: test
+        run: unset CI && cargo test
 
   e2e:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,20 @@ version = 3
 
 [[package]]
 name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli 0.27.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli",
+ "gimli 0.28.0",
 ]
 
 [[package]]
@@ -18,14 +27,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -57,6 +84,18 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "arrayvec"
@@ -128,6 +167,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,17 +285,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
- "addr2line",
+ "addr2line 0.21.0",
  "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.32.1",
  "rustc-demangle",
 ]
 
@@ -193,6 +355,12 @@ name = "base32"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -256,8 +424,14 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bit-vec"
@@ -375,7 +549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db629469a6955021b15eb99cf5983ae8dcf9d0432ba2a8295715efee232da912"
 dependencies = [
  "chrono",
- "derive_more",
+ "derive_more 0.99.17",
  "semver",
  "serde",
 ]
@@ -392,7 +566,7 @@ dependencies = [
  "build-info-common",
  "chrono",
  "format-buf",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "proc-macro-error",
  "proc-macro-hack",
@@ -469,6 +643,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cached"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec6d20b3d24b6c74e2c5331d2d3d8d1976a9883c7da179aa851afa4c90d62e36"
+dependencies = [
+ "hashbrown 0.12.3",
+ "instant",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,14 +682,14 @@ dependencies = [
  "lalrpop-util",
  "leb128",
  "logos",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "num_enum 0.6.1",
  "paste",
  "pretty",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.8",
  "stacker",
  "thiserror",
 ]
@@ -606,6 +792,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_derive",
+ "clap_lex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +927,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,10 +945,161 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bforest"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ebf2f2c0abc3a31cda70b20bae56b9aeb6ad0de00c3620bfef1a7e26220edfb"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d414ddd870ebce9b55eed9e803ef063436bd4d64160dd8e811ccbeb2c914f0"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.27.3",
+ "hashbrown 0.13.2",
+ "log",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b0065250c0c1fae99748aadc6003725e588542650886d76dd234eca8498598"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27320b5159cfa5eadcbebceda66ac145c0aa5cb7a31948550b9636f77924081b"
+
+[[package]]
+name = "cranelift-control"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bb54d1e129d6d3cf0e2a191ec2ba91aec1c290a048bc7595490a275d729d7a"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5656cb48246a511ab1bd22431122d8d23553b7c5f7f5ccff5569f47c0b708c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5321dc54f0f4e19f85d8e68543c63edfc255171cc5910c8b9a48e6210ffcdf2"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adff1f9152fd9970ad9cc14e0d4e1b0089a75d19f8538c4dc9e19aebbd53fe60"
+
+[[package]]
+name = "cranelift-native"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809bfa1db0b982b1796bc8c0002ab6bab959664df16095c289e567bdd22ade6f"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-wasm"
+version = "0.98.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892f9273ee0c7709e839fcee769f9db1630789be5dbdfa429d84e0de8ec3dd41"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "itertools",
+ "log",
+ "smallvec",
+ "wasmparser 0.107.0",
+ "wasmtime-types",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.9.0",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -732,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -748,6 +1133,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "cvt"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,10 +1168,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "der"
@@ -774,12 +1229,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.4",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.8-alpha.0"
+source = "git+https://github.com/dfinity-lab/derive_more?branch=master#9f1b894e6fde640da4e9ea71a8fc0e4dd98d01da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -882,6 +1361,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1406,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.9.9",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,12 +1447,12 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -978,6 +1495,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-ordinalize"
+version = "3.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
+dependencies = [
+ "num-bigint 0.4.4",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1530,18 @@ checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "escargot"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
+dependencies = [
+ "log",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1129,16 +1671,20 @@ dependencies = [
  "async-trait",
  "candid",
  "hex",
+ "ic-base-types 0.8.0",
  "ic-canister-log 0.2.0 (git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01)",
  "ic-canisters-http-types 0.8.0",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-certified-map",
  "ic-cketh-minter",
+ "ic-config",
  "ic-eth",
  "ic-metrics-encoder",
  "ic-nervous-system-common",
  "ic-stable-structures",
+ "ic-state-machine-tests",
+ "ic-test-utilities-load-wasm",
  "num",
  "num-derive",
  "num-traits",
@@ -1148,10 +1694,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fe-derive"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "num-bigint-dig",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "ff"
@@ -1159,7 +1734,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1180,6 +1755,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1332,6 +1917,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags 2.4.1",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,13 +1942,35 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 1.9.3",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1379,12 +1999,23 @@ dependencies = [
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
- "rand_core",
+ "ff 0.13.0",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1419,7 +2050,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.7",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.6",
 ]
 
 [[package]]
@@ -1435,6 +2075,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "hdrhistogram"
+version = "7.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b38e5c02b7c7be48c8dc5217c4f1634af2ea221caae2e024bffc7a7651c691"
+dependencies = [
+ "byteorder",
+ "num-traits",
 ]
 
 [[package]]
@@ -1454,6 +2104,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -1469,6 +2128,12 @@ dependencies = [
 
 [[package]]
 name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
@@ -1480,6 +2145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1523,6 +2197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +2227,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +2259,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "ic-adapter-metrics"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-adapter-metrics-service",
+ "ic-async-utils",
+ "prometheus",
+ "protobuf",
+ "slog",
+ "slog-async",
+ "tokio",
+ "tonic",
+ "tower",
+]
+
+[[package]]
+name = "ic-adapter-metrics-server"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "futures",
+ "ic-adapter-metrics-service",
+ "ic-async-utils",
+ "ic-logger",
+ "ic-metrics",
+ "prometheus",
+ "protobuf",
+ "slog",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "ic-adapter-metrics-service"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "prost",
+ "prost-build",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "ic-async-utils"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "async-stream",
+ "byte-unit",
+ "derive_more 0.99.17",
+ "futures",
+ "futures-util",
+ "hyper",
+ "ic-types",
+ "slog",
+ "tokio",
+ "tonic",
+ "tower",
 ]
 
 [[package]]
@@ -1664,6 +2418,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-canister-sandbox-backend-lib"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-base-types 0.8.0",
+ "ic-canister-sandbox-common",
+ "ic-config",
+ "ic-constants",
+ "ic-cycles-account-manager",
+ "ic-embedders",
+ "ic-interfaces",
+ "ic-logger",
+ "ic-replicated-state",
+ "ic-sys 0.8.0",
+ "ic-system-api",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "ic-wasm-types",
+ "libc",
+ "libflate",
+ "memory_tracker",
+ "nix 0.23.2",
+ "rayon",
+ "serde_json",
+ "slog",
+ "threadpool",
+]
+
+[[package]]
+name = "ic-canister-sandbox-common"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "bincode",
+ "bytes",
+ "ic-embedders",
+ "ic-interfaces",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-sys 0.8.0",
+ "ic-system-api",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "libc",
+ "nix 0.23.2",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-canister-sandbox-replica-controller"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-canister-sandbox-backend-lib",
+ "ic-canister-sandbox-common",
+ "ic-config",
+ "ic-embedders",
+ "ic-interfaces",
+ "ic-logger",
+ "ic-metrics",
+ "ic-replicated-state",
+ "ic-sys 0.8.0",
+ "ic-system-api",
+ "ic-types",
+ "ic-wasm-types",
+ "lazy_static",
+ "libc",
+ "nix 0.23.2",
+ "once_cell",
+ "prometheus",
+ "regex",
+ "serde_json",
+ "slog",
+ "which",
+]
+
+[[package]]
 name = "ic-canisters-http-types"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
@@ -1681,6 +2513,43 @@ dependencies = [
  "candid",
  "serde",
  "serde_bytes",
+]
+
+[[package]]
+name = "ic-canonical-state"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-base-types 0.8.0",
+ "ic-canonical-state-tree-hash",
+ "ic-certification-version",
+ "ic-crypto-tree-hash",
+ "ic-error-types 0.8.0",
+ "ic-protobuf 0.8.0",
+ "ic-registry-routing-table",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-types",
+ "itertools",
+ "leb128",
+ "phantom_newtype 0.8.0",
+ "scoped_threadpool",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-canonical-state-tree-hash"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-tree-hash",
+ "itertools",
+ "leb128",
+ "scoped_threadpool",
+ "thiserror",
 ]
 
 [[package]]
@@ -1734,6 +2603,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-certification"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "ic-crypto-tree-hash",
+ "ic-crypto-utils-threshold-sig",
+ "ic-crypto-utils-threshold-sig-der",
+ "ic-types",
+ "serde",
+ "serde_cbor",
+ "tree-deserializer",
+]
+
+[[package]]
+name = "ic-certification-version"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
 name = "ic-certified-map"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,7 +2634,7 @@ checksum = "197524aecec47db0b6c0c9f8821aad47272c2bd762c7a0ffe9715eaca0364061"
 dependencies = [
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1755,13 +2648,13 @@ dependencies = [
  "ethnum",
  "futures",
  "hex",
- "hex-literal",
+ "hex-literal 0.4.1",
  "ic-canister-log 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-canisters-http-types 0.9.0",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-cdk-timers",
- "ic-crypto-ecdsa-secp256k1",
+ "ic-crypto-ecdsa-secp256k1 0.9.0",
  "ic-crypto-sha3",
  "ic-ic00-types 0.9.0",
  "ic-metrics-encoder",
@@ -1771,7 +2664,7 @@ dependencies = [
  "icrc-ledger-types 0.1.4",
  "minicbor",
  "minicbor-derive",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "phantom_newtype 0.9.0",
  "rlp",
@@ -1786,9 +2679,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-config"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "ic-base-types 0.8.0",
+ "ic-protobuf 0.8.0",
+ "ic-registry-subnet-type",
+ "ic-sys 0.8.0",
+ "ic-types",
+ "json5",
+ "serde",
+ "slog",
+ "tempfile",
+ "url",
+]
+
+[[package]]
 name = "ic-constants"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+
+[[package]]
+name = "ic-context-logger"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "slog",
+]
+
+[[package]]
+name = "ic-crypto"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "clap",
+ "ed25519-consensus",
+ "hex",
+ "ic-adapter-metrics-server",
+ "ic-async-utils",
+ "ic-base-types 0.8.0",
+ "ic-config",
+ "ic-crypto-interfaces-sig-verification",
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-internal-basic-sig-iccsa",
+ "ic-crypto-internal-csp",
+ "ic-crypto-internal-logmon",
+ "ic-crypto-internal-seed",
+ "ic-crypto-internal-threshold-sig-bls12381",
+ "ic-crypto-internal-threshold-sig-ecdsa",
+ "ic-crypto-internal-types",
+ "ic-crypto-standalone-sig-verifier",
+ "ic-crypto-tls-cert-validation",
+ "ic-crypto-tls-interfaces",
+ "ic-crypto-utils-basic-sig",
+ "ic-crypto-utils-time",
+ "ic-crypto-utils-tls",
+ "ic-interfaces",
+ "ic-interfaces-registry",
+ "ic-logger",
+ "ic-metrics",
+ "ic-protobuf 0.8.0",
+ "ic-registry-client-fake",
+ "ic-registry-client-helpers",
+ "ic-registry-keys",
+ "ic-registry-proto-data-provider",
+ "ic-types",
+ "parking_lot 0.12.1",
+ "serde",
+ "slog",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+ "tempfile",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "ic-crypto-ecdsa-secp256k1"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "k256",
+ "lazy_static",
+ "num-bigint 0.4.4",
+ "pem 1.1.1",
+ "rand",
+ "simple_asn1",
+ "zeroize",
+]
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
@@ -1797,10 +2779,307 @@ source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4
 dependencies = [
  "k256",
  "lazy_static",
- "num-bigint",
- "pem",
+ "num-bigint 0.4.4",
+ "pem 1.1.1",
  "rand",
  "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-ecdsa-secp256r1"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-getrandom-for-wasm",
+ "lazy_static",
+ "num-bigint 0.4.4",
+ "p256",
+ "pem 1.1.1",
+ "rand",
+ "rand_chacha",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-extended-bip32"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-internal-threshold-sig-ecdsa",
+]
+
+[[package]]
+name = "ic-crypto-getrandom-for-wasm"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "getrandom 0.2.11",
+]
+
+[[package]]
+name = "ic-crypto-iccsa"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-internal-basic-sig-iccsa",
+]
+
+[[package]]
+name = "ic-crypto-interfaces-sig-verification"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-types",
+]
+
+[[package]]
+name = "ic-crypto-internal-basic-sig-cose"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-internal-basic-sig-der-utils",
+ "ic-crypto-internal-basic-sig-ecdsa-secp256r1",
+ "ic-crypto-internal-basic-sig-rsa-pkcs1",
+ "ic-types",
+ "serde",
+ "serde_cbor",
+ "simple_asn1",
+]
+
+[[package]]
+name = "ic-crypto-internal-basic-sig-der-utils"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "ic-types",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-basic-sig-ecdsa-secp256k1"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "ic-crypto-ecdsa-secp256k1 0.1.0",
+ "ic-crypto-internal-basic-sig-der-utils",
+ "ic-crypto-internal-types",
+ "ic-crypto-secrets-containers",
+ "ic-types",
+ "serde",
+ "serde_bytes",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-basic-sig-ecdsa-secp256r1"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "ic-crypto-ecdsa-secp256r1",
+ "ic-crypto-internal-basic-sig-der-utils",
+ "ic-crypto-internal-types",
+ "ic-crypto-secrets-containers",
+ "ic-types",
+ "p256",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-basic-sig-ed25519"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "curve25519-dalek",
+ "ed25519-consensus",
+ "hex",
+ "ic-crypto-internal-basic-sig-der-utils",
+ "ic-crypto-internal-seed",
+ "ic-crypto-internal-types",
+ "ic-crypto-secrets-containers",
+ "ic-protobuf 0.8.0",
+ "ic-types",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-basic-sig-iccsa"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "hex",
+ "ic-certification",
+ "ic-crypto-internal-basic-sig-der-utils",
+ "ic-crypto-internal-types",
+ "ic-crypto-sha2 0.8.0",
+ "ic-crypto-tree-hash",
+ "ic-types",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "simple_asn1",
+]
+
+[[package]]
+name = "ic-crypto-internal-basic-sig-rsa-pkcs1"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-getrandom-for-wasm",
+ "ic-crypto-internal-basic-sig-der-utils",
+ "ic-crypto-sha2 0.8.0",
+ "ic-types",
+ "num-bigint 0.4.4",
+ "num-traits",
+ "pkcs8",
+ "rsa",
+ "serde",
+ "sha2 0.10.8",
+ "simple_asn1",
+]
+
+[[package]]
+name = "ic-crypto-internal-bls12-381-type"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "ic-crypto-getrandom-for-wasm",
+ "ic_bls12_381",
+ "itertools",
+ "lazy_static",
+ "pairing",
+ "paste",
+ "rand",
+ "rand_chacha",
+ "sha2 0.9.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-csp"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "async-trait",
+ "base64 0.11.0",
+ "hex",
+ "ic-adapter-metrics",
+ "ic-config",
+ "ic-crypto-internal-basic-sig-ecdsa-secp256k1",
+ "ic-crypto-internal-basic-sig-ecdsa-secp256r1",
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-internal-basic-sig-rsa-pkcs1",
+ "ic-crypto-internal-logmon",
+ "ic-crypto-internal-multi-sig-bls12381",
+ "ic-crypto-internal-seed",
+ "ic-crypto-internal-test-vectors",
+ "ic-crypto-internal-threshold-sig-bls12381",
+ "ic-crypto-internal-threshold-sig-ecdsa",
+ "ic-crypto-internal-tls",
+ "ic-crypto-internal-types",
+ "ic-crypto-node-key-validation",
+ "ic-crypto-secrets-containers",
+ "ic-crypto-sha2 0.8.0",
+ "ic-crypto-standalone-sig-verifier",
+ "ic-crypto-tls-interfaces",
+ "ic-crypto-utils-time",
+ "ic-interfaces",
+ "ic-logger",
+ "ic-metrics",
+ "ic-protobuf 0.8.0",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "parking_lot 0.12.1",
+ "prost",
+ "rand",
+ "rand_chacha",
+ "rcgen 0.10.0",
+ "serde",
+ "serde_cbor",
+ "simple_asn1",
+ "slog",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+ "stubborn-io",
+ "tarpc",
+ "tempfile",
+ "threadpool",
+ "time",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "x509-parser 0.15.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-hmac"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-internal-sha2 0.8.0",
+]
+
+[[package]]
+name = "ic-crypto-internal-logmon"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "convert_case 0.6.0",
+ "ic-metrics",
+ "prometheus",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "ic-crypto-internal-multi-sig-bls12381"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "hex",
+ "ic-crypto-internal-bls12-381-type",
+ "ic-crypto-internal-types",
+ "ic-crypto-secrets-containers",
+ "ic-crypto-sha2 0.8.0",
+ "ic-protobuf 0.8.0",
+ "ic-types",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-seed"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "ic-crypto-sha2 0.8.0",
+ "ic-types",
+ "rand",
+ "rand_chacha",
+ "serde",
  "zeroize",
 ]
 
@@ -1809,7 +3088,7 @@ name = "ic-crypto-internal-sha2"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -1817,7 +3096,157 @@ name = "ic-crypto-internal-sha2"
 version = "0.9.0"
 source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
- "sha2",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "ic-crypto-internal-test-vectors"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "hex",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "ic-crypto-internal-threshold-sig-bls12381"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "cached",
+ "hex",
+ "ic-crypto-internal-bls12-381-type",
+ "ic-crypto-internal-seed",
+ "ic-crypto-internal-threshold-sig-bls12381-der",
+ "ic-crypto-internal-types",
+ "ic-crypto-secrets-containers",
+ "ic-crypto-sha2 0.8.0",
+ "ic-types",
+ "lazy_static",
+ "parking_lot 0.12.1",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "strum_macros 0.23.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-threshold-sig-bls12381-der"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "simple_asn1",
+]
+
+[[package]]
+name = "ic-crypto-internal-threshold-sig-ecdsa"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "fe-derive",
+ "hex",
+ "hex-literal 0.3.4",
+ "ic-crypto-internal-hmac",
+ "ic-crypto-internal-seed",
+ "ic-crypto-internal-types",
+ "ic-crypto-secrets-containers",
+ "ic-crypto-sha2 0.8.0",
+ "ic-types",
+ "k256",
+ "lazy_static",
+ "p256",
+ "paste",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-tls"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-secrets-containers",
+ "ic-types",
+ "rand",
+ "rcgen 0.11.3",
+ "serde",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-internal-types"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "arrayvec 0.5.2",
+ "base64 0.11.0",
+ "hex",
+ "ic-protobuf 0.8.0",
+ "phantom_newtype 0.8.0",
+ "serde",
+ "serde_cbor",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "ic-crypto-node-key-validation"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "ic-base-types 0.8.0",
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-internal-multi-sig-bls12381",
+ "ic-crypto-internal-threshold-sig-bls12381",
+ "ic-crypto-internal-threshold-sig-ecdsa",
+ "ic-crypto-internal-types",
+ "ic-crypto-tls-cert-validation",
+ "ic-interfaces",
+ "ic-protobuf 0.8.0",
+ "ic-types",
+ "serde",
+]
+
+[[package]]
+name = "ic-crypto-prng"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-sha2 0.8.0",
+ "ic-interfaces",
+ "ic-types",
+ "rand",
+ "rand_chacha",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "ic-crypto-secrets-containers"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -1842,6 +3271,201 @@ version = "0.9.0"
 source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "sha3 0.9.1",
+]
+
+[[package]]
+name = "ic-crypto-standalone-sig-verifier"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-iccsa",
+ "ic-crypto-internal-basic-sig-cose",
+ "ic-crypto-internal-basic-sig-der-utils",
+ "ic-crypto-internal-basic-sig-ecdsa-secp256k1",
+ "ic-crypto-internal-basic-sig-ecdsa-secp256r1",
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-internal-basic-sig-iccsa",
+ "ic-crypto-internal-basic-sig-rsa-pkcs1",
+ "ic-crypto-internal-types",
+ "ic-crypto-sha2 0.8.0",
+ "ic-types",
+]
+
+[[package]]
+name = "ic-crypto-tecdsa"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-internal-threshold-sig-ecdsa",
+ "ic-types",
+]
+
+[[package]]
+name = "ic-crypto-test-utils-keys"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "ic-protobuf 0.8.0",
+ "ic-types",
+]
+
+[[package]]
+name = "ic-crypto-tls-cert-validation"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "ic-base-types 0.8.0",
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-internal-types",
+ "ic-protobuf 0.8.0",
+ "ic-types",
+ "serde",
+ "x509-parser 0.14.0",
+]
+
+[[package]]
+name = "ic-crypto-tls-interfaces"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "async-trait",
+ "ic-crypto-sha2 0.8.0",
+ "ic-protobuf 0.8.0",
+ "ic-types",
+ "serde",
+ "tokio",
+ "tokio-rustls",
+ "x509-parser 0.15.1",
+]
+
+[[package]]
+name = "ic-crypto-tree-hash"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "assert_matches",
+ "ic-crypto-internal-types",
+ "ic-crypto-sha2 0.8.0",
+ "ic-protobuf 0.8.0",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-crypto-utils-basic-sig"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "ed25519-consensus",
+ "ic-base-types 0.8.0",
+ "ic-crypto-internal-basic-sig-der-utils",
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-internal-types",
+ "ic-protobuf 0.8.0",
+ "simple_asn1",
+]
+
+[[package]]
+name = "ic-crypto-utils-threshold-sig"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "ic-crypto-internal-threshold-sig-bls12381",
+ "ic-crypto-internal-types",
+ "ic-types",
+]
+
+[[package]]
+name = "ic-crypto-utils-threshold-sig-der"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "ic-crypto-internal-threshold-sig-bls12381-der",
+ "ic-crypto-internal-types",
+ "ic-types",
+]
+
+[[package]]
+name = "ic-crypto-utils-time"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-interfaces",
+ "ic-logger",
+ "ic-types",
+ "slog",
+]
+
+[[package]]
+name = "ic-crypto-utils-tls"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-base-types 0.8.0",
+ "ic-crypto-tls-interfaces",
+ "tokio-rustls",
+ "x509-parser 0.15.1",
+]
+
+[[package]]
+name = "ic-cycles-account-manager"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-base-types 0.8.0",
+ "ic-config",
+ "ic-ic00-types 0.8.0",
+ "ic-interfaces",
+ "ic-logger",
+ "ic-nns-constants",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-types",
+ "prometheus",
+ "serde",
+ "slog",
+]
+
+[[package]]
+name = "ic-embedders"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "anyhow",
+ "ic-config",
+ "ic-cycles-account-manager",
+ "ic-interfaces",
+ "ic-logger",
+ "ic-metrics",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-sys 0.8.0",
+ "ic-system-api",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "ic-utils-lru-cache",
+ "ic-wasm-types",
+ "libc",
+ "libflate",
+ "memory_tracker",
+ "nix 0.23.2",
+ "prometheus",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "slog",
+ "slog-term",
+ "wasm-encoder 0.31.1",
+ "wasmparser 0.109.0",
+ "wasmtime",
+ "wasmtime-environ",
+ "wasmtime-runtime",
 ]
 
 [[package]]
@@ -1873,13 +3497,70 @@ dependencies = [
  "async-trait",
  "ethers-core",
  "ethers-providers",
- "getrandom",
+ "getrandom 0.2.11",
  "hex",
  "ic-cdk",
  "ic-cdk-macros",
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "ic-execution-environment"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "candid",
+ "crossbeam-channel",
+ "escargot",
+ "hex",
+ "ic-base-types 0.8.0",
+ "ic-btc-interface",
+ "ic-canister-sandbox-replica-controller",
+ "ic-config",
+ "ic-constants",
+ "ic-crypto-prng",
+ "ic-crypto-tecdsa",
+ "ic-crypto-tree-hash",
+ "ic-cycles-account-manager",
+ "ic-embedders",
+ "ic-error-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-interfaces",
+ "ic-interfaces-state-manager",
+ "ic-logger",
+ "ic-metrics",
+ "ic-nns-constants",
+ "ic-registry-provisional-whitelist",
+ "ic-registry-routing-table",
+ "ic-registry-subnet-features",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-state-layout",
+ "ic-sys 0.8.0",
+ "ic-system-api",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "ic-utils-lru-cache",
+ "ic-wasm-types",
+ "lazy_static",
+ "memory_tracker",
+ "nix 0.23.2",
+ "num-rational 0.2.4",
+ "num-traits",
+ "phantom_newtype 0.8.0",
+ "prometheus",
+ "rand",
+ "scoped_threadpool",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "slog",
+ "strum 0.23.0",
+ "threadpool",
+ "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -1934,11 +3615,68 @@ dependencies = [
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "icrc-ledger-types 0.1.2",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "serde",
  "serde_bytes",
  "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-interfaces"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "async-trait",
+ "derive_more 0.99.8-alpha.0",
+ "ic-base-types 0.8.0",
+ "ic-crypto-interfaces-sig-verification",
+ "ic-crypto-tree-hash",
+ "ic-error-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-interfaces-state-manager",
+ "ic-protobuf 0.8.0",
+ "ic-registry-provisional-whitelist",
+ "ic-registry-subnet-type",
+ "ic-sys 0.8.0",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "ic-wasm-types",
+ "prost",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "thiserror",
+ "tower",
+]
+
+[[package]]
+name = "ic-interfaces-certified-stream-store"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-types",
+]
+
+[[package]]
+name = "ic-interfaces-registry"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-types",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "ic-interfaces-state-manager"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-tree-hash",
+ "ic-types",
+ "phantom_newtype 0.8.0",
  "thiserror",
 ]
 
@@ -1980,6 +3718,77 @@ dependencies = [
  "candid",
  "hex",
  "serde",
+]
+
+[[package]]
+name = "ic-logger"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "chrono",
+ "ic-config",
+ "ic-context-logger",
+ "ic-protobuf 0.8.0",
+ "serde",
+ "slog",
+ "slog-async",
+ "slog-json",
+ "slog-scope",
+ "slog-term",
+]
+
+[[package]]
+name = "ic-messaging"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-base-types 0.8.0",
+ "ic-certification-version",
+ "ic-config",
+ "ic-constants",
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-tree-hash",
+ "ic-crypto-utils-threshold-sig-der",
+ "ic-cycles-account-manager",
+ "ic-error-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-interfaces",
+ "ic-interfaces-certified-stream-store",
+ "ic-interfaces-registry",
+ "ic-interfaces-state-manager",
+ "ic-logger",
+ "ic-metrics",
+ "ic-protobuf 0.8.0",
+ "ic-registry-client-fake",
+ "ic-registry-client-helpers",
+ "ic-registry-keys",
+ "ic-registry-proto-data-provider",
+ "ic-registry-provisional-whitelist",
+ "ic-registry-routing-table",
+ "ic-registry-subnet-features",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "prometheus",
+ "slog",
+]
+
+[[package]]
+name = "ic-metrics"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "futures",
+ "ic-adapter-metrics",
+ "ic-logger",
+ "libc",
+ "procfs",
+ "prometheus",
+ "slog",
+ "slog-async",
+ "tokio",
+ "tokio-metrics",
 ]
 
 [[package]]
@@ -2079,10 +3888,297 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-registry-client-fake"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-interfaces-registry",
+ "ic-types",
+]
+
+[[package]]
+name = "ic-registry-client-helpers"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-base-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-interfaces-registry",
+ "ic-protobuf 0.8.0",
+ "ic-registry-common-proto",
+ "ic-registry-keys",
+ "ic-registry-provisional-whitelist",
+ "ic-registry-routing-table",
+ "ic-registry-subnet-features",
+ "ic-types",
+ "serde_cbor",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-registry-common-proto"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "ic-registry-keys"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "candid",
+ "ic-base-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-types",
+ "serde",
+]
+
+[[package]]
+name = "ic-registry-proto-data-provider"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "bytes",
+ "ic-interfaces-registry",
+ "ic-registry-common-proto",
+ "ic-registry-transport",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "thiserror",
+]
+
+[[package]]
+name = "ic-registry-provisional-whitelist"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-base-types 0.8.0",
+ "ic-protobuf 0.8.0",
+]
+
+[[package]]
+name = "ic-registry-routing-table"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "candid",
+ "ic-base-types 0.8.0",
+ "ic-protobuf 0.8.0",
+ "serde",
+]
+
+[[package]]
+name = "ic-registry-subnet-features"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "candid",
+ "ic-ic00-types 0.8.0",
+ "ic-protobuf 0.8.0",
+ "serde",
+]
+
+[[package]]
+name = "ic-registry-subnet-type"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "candid",
+ "ic-protobuf 0.8.0",
+ "serde",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+]
+
+[[package]]
+name = "ic-registry-transport"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "bytes",
+ "candid",
+ "ic-base-types 0.8.0",
+ "ic-protobuf 0.8.0",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "ic-replicated-state"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "cvt",
+ "ic-base-types 0.8.0",
+ "ic-btc-interface",
+ "ic-btc-types-internal 0.1.0",
+ "ic-certification-version",
+ "ic-config",
+ "ic-constants",
+ "ic-crypto-internal-basic-sig-ed25519",
+ "ic-crypto-sha2 0.8.0",
+ "ic-crypto-test-utils-keys",
+ "ic-error-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-interfaces",
+ "ic-logger",
+ "ic-protobuf 0.8.0",
+ "ic-registry-routing-table",
+ "ic-registry-subnet-features",
+ "ic-registry-subnet-type",
+ "ic-sys 0.8.0",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "ic-wasm-types",
+ "lazy_static",
+ "libc",
+ "maplit",
+ "nix 0.23.2",
+ "phantom_newtype 0.8.0",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "slog",
+ "tempfile",
+ "uuid",
+]
+
+[[package]]
 name = "ic-stable-structures"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95dce29e3ceb0e6da3e78b305d95365530f2efd2146ca18590c0ef3aa6038568"
+
+[[package]]
+name = "ic-state-layout"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "hex",
+ "ic-base-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-logger",
+ "ic-metrics",
+ "ic-protobuf 0.8.0",
+ "ic-replicated-state",
+ "ic-sys 0.8.0",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "ic-wasm-types",
+ "libc",
+ "prometheus",
+ "prost",
+ "scoped_threadpool",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "slog",
+ "tempfile",
+]
+
+[[package]]
+name = "ic-state-machine-tests"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "candid",
+ "ciborium",
+ "clap",
+ "hex",
+ "ic-config",
+ "ic-constants",
+ "ic-crypto",
+ "ic-crypto-ecdsa-secp256k1 0.1.0",
+ "ic-crypto-extended-bip32",
+ "ic-crypto-iccsa",
+ "ic-crypto-internal-seed",
+ "ic-crypto-internal-threshold-sig-bls12381",
+ "ic-crypto-internal-types",
+ "ic-crypto-test-utils-keys",
+ "ic-crypto-tree-hash",
+ "ic-crypto-utils-threshold-sig-der",
+ "ic-cycles-account-manager",
+ "ic-error-types 0.8.0",
+ "ic-execution-environment",
+ "ic-ic00-types 0.8.0",
+ "ic-interfaces",
+ "ic-interfaces-certified-stream-store",
+ "ic-interfaces-registry",
+ "ic-interfaces-state-manager",
+ "ic-logger",
+ "ic-messaging",
+ "ic-metrics",
+ "ic-protobuf 0.8.0",
+ "ic-registry-client-fake",
+ "ic-registry-client-helpers",
+ "ic-registry-keys",
+ "ic-registry-proto-data-provider",
+ "ic-registry-provisional-whitelist",
+ "ic-registry-routing-table",
+ "ic-registry-subnet-features",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-state-layout",
+ "ic-state-manager",
+ "ic-test-state-machine-client",
+ "ic-test-utilities-metrics",
+ "ic-test-utilities-registry",
+ "ic-types",
+ "maplit",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "slog",
+ "slog-term",
+ "tempfile",
+ "tokio",
+ "wat",
+]
+
+[[package]]
+name = "ic-state-manager"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "bit-vec 0.6.3",
+ "crossbeam-channel",
+ "hex",
+ "ic-base-types 0.8.0",
+ "ic-canonical-state",
+ "ic-canonical-state-tree-hash",
+ "ic-config",
+ "ic-crypto-sha2 0.8.0",
+ "ic-crypto-tree-hash",
+ "ic-error-types 0.8.0",
+ "ic-interfaces",
+ "ic-interfaces-certified-stream-store",
+ "ic-interfaces-state-manager",
+ "ic-logger",
+ "ic-metrics",
+ "ic-protobuf 0.8.0",
+ "ic-registry-routing-table",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-state-layout",
+ "ic-sys 0.8.0",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "nix 0.23.2",
+ "parking_lot 0.12.1",
+ "prometheus",
+ "prost",
+ "rand",
+ "rand_chacha",
+ "scoped_threadpool",
+ "serde",
+ "serde_bytes",
+ "slog",
+ "tempfile",
+ "tree-deserializer",
+ "uuid",
+]
 
 [[package]]
 name = "ic-sys"
@@ -2110,6 +4206,117 @@ dependencies = [
  "nix 0.24.3",
  "phantom_newtype 0.9.0",
  "wsl",
+]
+
+[[package]]
+name = "ic-system-api"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "candid",
+ "ic-base-types 0.8.0",
+ "ic-btc-interface",
+ "ic-config",
+ "ic-constants",
+ "ic-cycles-account-manager",
+ "ic-error-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-interfaces",
+ "ic-logger",
+ "ic-nns-constants",
+ "ic-registry-routing-table",
+ "ic-registry-subnet-type",
+ "ic-replicated-state",
+ "ic-sys 0.8.0",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "ic-wasm-types",
+ "prometheus",
+ "serde",
+ "serde_bytes",
+ "slog",
+]
+
+[[package]]
+name = "ic-test-state-machine-client"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cadf6ac4a193a8a45287da67c6c385f118d9266f46d6d98e40fbbd469d3822e"
+dependencies = [
+ "candid",
+ "ciborium",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "ic-test-utilities-load-wasm"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "cargo_metadata",
+ "escargot",
+]
+
+[[package]]
+name = "ic-test-utilities-metrics"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-metrics",
+ "prometheus",
+]
+
+[[package]]
+name = "ic-test-utilities-registry"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-interfaces",
+ "ic-interfaces-registry",
+ "ic-protobuf 0.8.0",
+ "ic-registry-client-fake",
+ "ic-registry-keys",
+ "ic-registry-proto-data-provider",
+ "ic-registry-subnet-features",
+ "ic-registry-subnet-type",
+ "ic-types",
+]
+
+[[package]]
+name = "ic-types"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "base64 0.11.0",
+ "bincode",
+ "candid",
+ "chrono",
+ "derive_more 0.99.8-alpha.0",
+ "hex",
+ "ic-base-types 0.8.0",
+ "ic-btc-types-internal 0.1.0",
+ "ic-constants",
+ "ic-crypto-internal-types",
+ "ic-crypto-sha2 0.8.0",
+ "ic-crypto-tree-hash",
+ "ic-error-types 0.8.0",
+ "ic-ic00-types 0.8.0",
+ "ic-protobuf 0.8.0",
+ "ic-utils 0.8.0",
+ "maplit",
+ "once_cell",
+ "phantom_newtype 0.8.0",
+ "prost",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_json",
+ "serde_with",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+ "thiserror",
+ "thousands",
 ]
 
 [[package]]
@@ -2152,10 +4359,47 @@ version = "0.9.0"
 source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 
 [[package]]
+name = "ic-utils-lru-cache"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-types",
+ "lru",
+]
+
+[[package]]
+name = "ic-wasm-types"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-sha2 0.8.0",
+ "ic-protobuf 0.8.0",
+ "ic-sys 0.8.0",
+ "ic-types",
+ "ic-utils 0.8.0",
+ "serde",
+]
+
+[[package]]
 name = "ic0"
 version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
+
+[[package]]
+name = "ic_bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682cb199cd8fcb582a6023325d571a6464edda26c8063fe04b6f6082a1a363c"
+dependencies = [
+ "digest 0.9.0",
+ "ff 0.12.1",
+ "group 0.12.1",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "icp-ledger"
@@ -2221,7 +4465,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2233,12 +4477,18 @@ dependencies = [
  "candid",
  "crc32fast",
  "hex",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "serde",
  "serde_bytes",
- "sha2",
+ "sha2 0.10.8",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2296,6 +4546,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2318,6 +4569,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,8 +4591,8 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
- "rustix",
+ "hermit-abi 0.3.3",
+ "rustix 0.38.24",
  "windows-sys",
 ]
 
@@ -2376,8 +4638,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.5",
- "pem",
- "ring",
+ "pem 1.1.1",
+ "ring 0.16.20",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -2393,7 +4655,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.8",
  "signature",
 ]
 
@@ -2443,6 +4705,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "leb128"
@@ -2455,6 +4720,26 @@ name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libflate"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
+dependencies = [
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libm"
@@ -2470,8 +4755,14 @@ checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
  "bitflags 2.4.1",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2528,6 +4819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,10 +4836,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -2551,12 +4863,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memfd"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
+dependencies = [
+ "rustix 0.38.24",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memory_tracker"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "bit-vec 0.5.1",
+ "ic-config",
+ "ic-logger",
+ "ic-replicated-state",
+ "ic-sys 0.8.0",
+ "ic-utils 0.8.0",
+ "lazy_static",
+ "libc",
+ "nix 0.23.2",
+ "slog",
 ]
 
 [[package]]
@@ -2617,7 +4973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -2649,6 +5005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,7 +5026,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -2676,7 +5038,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -2701,11 +5063,22 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.4.1",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2719,6 +5092,24 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "serde",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -2764,12 +5155,24 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-integer",
  "num-traits",
 ]
@@ -2782,6 +5185,16 @@ checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "libc",
 ]
 
 [[package]]
@@ -2827,12 +5240,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.13.2",
+ "indexmap 1.9.3",
+ "memchr",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -2878,6 +5321,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "pairing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+dependencies = [
+ "group 0.12.1",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,12 +5394,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2921,7 +5435,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets",
 ]
@@ -2939,6 +5453,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
+dependencies = [
+ "base64 0.21.5",
+ "serde",
 ]
 
 [[package]]
@@ -2998,7 +5522,7 @@ checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -3089,6 +5613,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,6 +5709,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7dbe9ed3b56368bd99483eb32fe9c17fdd3730aebadc906918ce78d54c7eeb4"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,6 +5810,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot 0.11.2",
+ "procfs",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "proptest"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +5867,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,6 +5900,21 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psm"
@@ -3346,7 +5968,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3356,7 +5978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -3365,7 +5996,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -3374,7 +6005,61 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem 1.1.1",
+ "ring 0.16.20",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
+dependencies = [
+ "pem 3.0.2",
+ "ring 0.16.20",
+ "time",
+ "yasna",
+ "zeroize",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3392,9 +6077,22 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.11",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash",
+ "slice-group-by",
+ "smallvec",
 ]
 
 [[package]]
@@ -3501,10 +6199,24 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom 0.2.11",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3536,6 +6248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,6 +6273,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ef35bf3e7fe15a53c4ab08a998e42271eab13eb0db224126bc7bc4c4bad96d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.8",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3580,6 +6319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,6 +6340,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,8 +6371,30 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.11",
  "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+dependencies = [
+ "log",
+ "ring 0.17.5",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3626,7 +6416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "cfg-if",
- "derive_more",
+ "derive_more 0.99.17",
  "parity-scale-codec",
  "scale-info-derive",
 ]
@@ -3654,6 +6444,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring 0.17.5",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "seahash"
@@ -3770,6 +6570,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+dependencies = [
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,13 +6638,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3824,7 +6677,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "thiserror",
  "time",
@@ -3846,12 +6699,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 dependencies = [
  "erased-serde",
+]
+
+[[package]]
+name = "slog-async"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-json"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_json",
+ "slog",
+ "time",
+]
+
+[[package]]
+name = "slog-scope"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
+dependencies = [
+ "arc-swap",
+ "lazy_static",
+ "slog",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
+dependencies = [
+ "atty",
+ "slog",
+ "term",
+ "thread_local",
+ "time",
 ]
 
 [[package]]
@@ -3896,6 +6804,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3904,6 +6818,18 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
@@ -3932,10 +6858,16 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "phf_shared",
  "precomputed-hash",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -4001,10 +6933,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "stubborn-io"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b261fbca19f25e0ac726f6efb3c3f53949e18ba4b126c16f8ca625730daa1a9c"
+dependencies = [
+ "log",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -4041,6 +6990,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4062,10 +7029,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+
+[[package]]
+name = "tarpc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f07cb5fb67b0a90ea954b5ffd2fac9944ffef5937c801b987d3f8913f0c37348"
+dependencies = [
+ "anyhow",
+ "fnv",
+ "futures",
+ "humantime",
+ "opentelemetry",
+ "pin-project",
+ "rand",
+ "serde",
+ "static_assertions",
+ "tarpc-plugins",
+ "thiserror",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "tarpc-plugins"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "tempfile"
@@ -4075,8 +7089,8 @@ checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
- "rustix",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.24",
  "windows-sys",
 ]
 
@@ -4107,6 +7121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4133,6 +7153,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
 name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,6 +7179,8 @@ checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4195,9 +7236,83 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.5",
+ "tokio-macros",
  "windows-sys",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+dependencies = [
+ "bincode",
+ "bytes",
+ "educe",
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -4210,6 +7325,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
  "tracing",
 ]
@@ -4252,6 +7368,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.5",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "hdrhistogram",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4263,6 +7447,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4286,6 +7471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -4296,6 +7482,40 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "tree-deserializer"
+version = "0.8.0"
+source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
+dependencies = [
+ "ic-crypto-tree-hash",
+ "leb128",
+ "serde",
 ]
 
 [[package]]
@@ -4395,6 +7615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,6 +7629,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -4416,6 +7643,16 @@ name = "uuid"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+dependencies = [
+ "getrandom 0.2.11",
+ "serde",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"
@@ -4431,6 +7668,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4500,6 +7743,243 @@ version = "0.2.88"
 source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f81ab4bf345cda2bc39#d50634da14c5bd031edd4f81ab4bf345cda2bc39"
 
 [[package]]
+name = "wasm-encoder"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41763f20eafed1399fff1afb466496d3a959f58241436cfdc17e3f5ca954de16"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822b645bf4f2446b949776ffca47e2af60b167209ffb70814ef8779d299cd421"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
+dependencies = [
+ "indexmap 1.9.3",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.109.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf9564f29de2890ee34406af52d2a92dec6ef044c8ddfc5add5db8dcfd36e6c"
+dependencies = [
+ "indexmap 2.1.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmtime"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028253baf4df6e0823481845a380117de2b7f42166261551db7d097d60cfc685"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bumpalo",
+ "cfg-if",
+ "fxprof-processed-profile",
+ "indexmap 1.9.3",
+ "libc",
+ "log",
+ "object 0.30.4",
+ "once_cell",
+ "paste",
+ "psm",
+ "rayon",
+ "serde",
+ "serde_json",
+ "target-lexicon",
+ "wasmparser 0.107.0",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-jit",
+ "wasmtime-runtime",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76c6e968fb3df273a8140bb9e02693b17da1f53a3bbafa0a5811e8ef1031cd8"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696333ffdbd9fabb486d8a5ee82c75fcd22d199446d3df04935a286fcbb40100"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "cranelift-wasm",
+ "gimli 0.27.3",
+ "log",
+ "object 0.30.4",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.107.0",
+ "wasmtime-cranelift-shared",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-cranelift-shared"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434899162f65339ae7710f6fba91083b86e707cb618a8f4e8b037b8d46223d56"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-native",
+ "gimli 0.27.3",
+ "object 0.30.4",
+ "target-lexicon",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1189b2fa0e7fbf71a06c7c909ae7f8f0085f8f4e4365926d6ff1052e024effe9"
+dependencies = [
+ "anyhow",
+ "cranelift-entity",
+ "gimli 0.27.3",
+ "indexmap 1.9.3",
+ "log",
+ "object 0.30.4",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.107.0",
+ "wasmtime-types",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b904e4920c5725dae5d2445c5923092f1d0dead3a521bd7f4218d7a9496842"
+dependencies = [
+ "addr2line 0.19.0",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpp_demangle",
+ "gimli 0.27.3",
+ "log",
+ "object 0.30.4",
+ "rustc-demangle",
+ "rustix 0.37.27",
+ "serde",
+ "target-lexicon",
+ "wasmtime-environ",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-runtime",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7228ed7aaedec75d6bd298f857e42f4626cffdb7b577c018eb2075c65d44dcf"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517750d84b6ebdb2c32226cee412c7e6aa48e4cebbb259d9a227b4317426adc6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89ef7f9d70f30fc5dfea15b61b65b81363bf8b3881ab76de3a7b24905c4e83a"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "indexmap 1.9.3",
+ "libc",
+ "log",
+ "mach",
+ "memfd",
+ "memoffset 0.8.0",
+ "paste",
+ "rand",
+ "rustix 0.37.27",
+ "sptr",
+ "wasmtime-asm-macros",
+ "wasmtime-environ",
+ "wasmtime-jit-debug",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-types"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac19aadf941ad333cbb0307121482700d925a99624d4110859d69b7f658b69d"
+dependencies = [
+ "cranelift-entity",
+ "serde",
+ "thiserror",
+ "wasmparser 0.107.0",
+]
+
+[[package]]
+name = "wast"
+version = "67.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a974d82fac092b5227c1663e16514e7a85f32014e22e6fdcb08b71aec9d3fb1e"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.36.2",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb220934f92f8551144c0003d1bc57a060674c99139f45ed623fbbf6d9262e7"
+dependencies = [
+ "wast",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,6 +7987,18 @@ checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.24",
 ]
 
 [[package]]
@@ -4669,6 +8161,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs",
+ "base64 0.13.1",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring 0.16.20",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4682,6 +8210,35 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -135,7 +135,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -202,9 +202,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "base64ct"
@@ -273,9 +273,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -316,47 +316,26 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
+checksum = "bf617fabf5cdbdc92f774bfe5062d870f228b80056d41180797abf48bed4056e"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.12.3",
+ "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
+checksum = "f404657a7ea7b5249e36808dff544bc88a28f26e0ac40009f674b7a009d14be3"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
+ "once_cell",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
+ "syn_derive",
 ]
 
 [[package]]
@@ -476,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -538,14 +517,14 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
 dependencies = [
  "serde",
 ]
@@ -577,6 +556,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -668,13 +653,14 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa72a10d0e914cad6bcad4e7409e68d230c1c2db67896e19a37f758b1fcbdab5"
+checksum = "a5104de16b218eddf8e34ffe2f86f74bfa4e61e95a1b89732fccf6325efd0557"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "hex",
+ "proptest",
  "serde",
 ]
 
@@ -700,6 +686,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,9 +703,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -731,9 +727,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
+checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -779,9 +775,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_more"
@@ -924,9 +923,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
+checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -966,7 +965,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes",
  "hex",
  "k256",
@@ -995,23 +994,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1076,7 +1064,7 @@ dependencies = [
  "ethabi",
  "generic-array",
  "k256",
- "num_enum 0.7.0",
+ "num_enum 0.7.1",
  "open-fastrlp",
  "rand",
  "rlp",
@@ -1097,7 +1085,7 @@ checksum = "6838fa110e57d572336178b7c79e94ff88ef976306852d8cb87d9e5b1fc7c0b5"
 dependencies = [
  "async-trait",
  "auto_impl",
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes",
  "const-hex",
  "enr",
@@ -1237,9 +1225,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1252,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1262,15 +1250,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1279,32 +1267,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-timer"
@@ -1318,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1356,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1402,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -1412,7 +1400,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1436,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "hashers"
@@ -1496,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1551,7 +1539,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1560,16 +1548,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -1605,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "base32",
  "byte-unit",
@@ -1648,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -1688,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "candid",
  "serde",
@@ -1759,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "askama",
  "async-trait",
@@ -1780,7 +1768,7 @@ dependencies = [
  "ic-stable-structures",
  "ic-utils-ensure",
  "icrc-ledger-client-cdk",
- "icrc-ledger-types 0.1.3",
+ "icrc-ledger-types 0.1.4",
  "minicbor",
  "minicbor-derive",
  "num-bigint",
@@ -1794,6 +1782,7 @@ dependencies = [
  "strum_macros 0.24.3",
  "thiserror",
  "thousands",
+ "time",
 ]
 
 [[package]]
@@ -1804,7 +1793,7 @@ source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e505
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "k256",
  "lazy_static",
@@ -1826,7 +1815,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "sha2",
 ]
@@ -1842,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -1850,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -1869,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -1915,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -2077,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "bincode",
  "candid",
@@ -2112,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -2143,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "cvt",
  "hex",
@@ -2160,13 +2149,13 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 
 [[package]]
 name = "ic0"
-version = "0.18.12"
+version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16efdbe5d9b0ea368da50aedbf7640a054139569236f1a5249deb5fd9af5a5d5"
+checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
 
 [[package]]
 name = "icp-ledger"
@@ -2201,18 +2190,18 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "async-trait",
  "candid",
- "icrc-ledger-types 0.1.3",
+ "icrc-ledger-types 0.1.4",
  "serde",
 ]
 
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "async-trait",
  "candid",
@@ -2237,8 +2226,8 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-types"
-version = "0.1.3"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+version = "0.1.4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "base32",
  "candid",
@@ -2311,12 +2300,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -2330,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -2362,9 +2351,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2386,7 +2375,7 @@ version = "8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "pem",
  "ring",
  "serde",
@@ -2463,21 +2452,38 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.7"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2509,7 +2515,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2540,9 +2546,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -2606,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
@@ -2732,7 +2738,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2775,6 +2781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2788,11 +2795,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
 dependencies = [
- "num_enum_derive 0.7.0",
+ "num_enum_derive 0.7.1",
 ]
 
 [[package]]
@@ -2804,19 +2811,19 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2908,13 +2915,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets",
 ]
@@ -2951,9 +2958,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
+checksum = "ae9cee2a55a544be8b89dc6848072af97a20f2422603c10865be2a42b580fff5"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2962,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
+checksum = "81d78524685f5ef2a3b3bd1cafbc9fcabb036253d9b1463e726a91cd16e2dfc2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2972,22 +2979,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
+checksum = "68bd1206e71118b5356dae5ddc61c8b11e28b09ef6a31acbd15ea48a28e0c227"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
+checksum = "7c747191d4ad9e4a4ab9c8798f1e82a39affe7ef9648390b7e5548d18e099de6"
 dependencies = [
  "once_cell",
  "pest",
@@ -3001,7 +3008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.1",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -3017,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fad1fec8a21b0ea2afa4e9981cff70f267294fe4"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#06b7f36fa6e4be5444961598c9bc951f2f0d1e5b"
 dependencies = [
  "candid",
  "serde",
@@ -3066,7 +3073,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3096,6 +3103,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3162,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -3186,21 +3199,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+dependencies = [
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -3235,11 +3248,27 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bitflags 2.4.1",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.2",
+ "unarray",
 ]
 
 [[package]]
@@ -3340,55 +3369,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "rand_xorshift"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "bitflags 1.3.2",
+ "rand_core",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3404,6 +3433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "rend"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,11 +3449,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.21.4",
+ "base64 0.21.5",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3437,6 +3472,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tower-service",
  "url",
@@ -3523,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c4216490d5a413bc6d10fa4742bd7d4955941d062c0ef873141d6b0e7b30fd"
+checksum = "076ba1058b036d3ca8bcafb1d54d0b0572e99d7ecd3e4222723e18ca8e9ca9a8"
 dependencies = [
  "arrayvec 0.7.4",
  "borsh",
@@ -3560,11 +3596,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3585,9 +3621,9 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scale-info"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0a159d0c45c12b20c5a844feb1fe4bea86e28f17b92a5f0c42193634d3782"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -3597,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e55f6d20e0e80d63733872b40e1227c0bce1e1ab81ba67d696339bfd7fd29"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -3641,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 dependencies = [
  "serde",
 ]
@@ -3662,9 +3698,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
@@ -3690,20 +3726,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -3829,15 +3865,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -3845,9 +3881,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -3922,7 +3958,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.2",
+ "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -3953,15 +3989,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3983,13 +4019,46 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4000,13 +4069,13 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
  "windows-sys",
 ]
@@ -4024,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
@@ -4039,22 +4108,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4065,12 +4134,13 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -4117,24 +4187,24 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "windows-sys",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4155,9 +4225,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 
 [[package]]
 name = "toml_edit"
@@ -4165,7 +4235,18 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.1",
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap 2.1.0",
  "toml_datetime",
  "winnow",
 ]
@@ -4178,11 +4259,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4190,20 +4270,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
@@ -4253,6 +4333,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -4327,9 +4413,9 @@ checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 
 [[package]]
 name = "version_check"
@@ -4371,15 +4457,15 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4403,7 +4489,7 @@ source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4415,9 +4501,9 @@ source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4455,10 +4541,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets",
 ]
@@ -4531,9 +4617,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
@@ -4599,9 +4685,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "12a3946ecfc929b583800f4629b6c25b88ac6e92a40ea5670f77112a85d40a8b"
 dependencies = [
  "zeroize_derive",
 ]
@@ -4614,5 +4700,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.39",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "ic-cketh-minter",
  "ic-config",
  "ic-eth",
+ "ic-ic00-types 0.8.0",
  "ic-metrics-encoder",
  "ic-nervous-system-common",
  "ic-stable-structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,20 @@ url = "2.4"
 async-trait = "0.1"
 hex = "0.4"
 
+[dev-dependencies]
+# assert_matches = "1.5.0"
+# ethers-core = "2.0.8"
+ic-base-types = { path = "../../../types/base_types" }
+ic-config = { path = "../../../config" }
+ic-crypto-test-utils-reproducible-rng = { path = "../../../crypto/test_utils/reproducible_rng" }
+ic-icrc1-ledger = { path = "../../../rosetta-api/icrc1/ledger" }
+ic-state-machine-tests = { path = "../../../state_machine_tests" }
+ic-test-utilities-load-wasm = { path = "../../../test_utilities/load_wasm" }
+# maplit = "1"
+# proptest = "1.0"
+# rand = "0.8"
+# scraper = "0.17.1"
+
 [workspace.dependencies]
 candid = { version = "0.9", features = ["parser"] }
 ic-canister-log = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ hex = "0.4"
 [dev-dependencies]
 # assert_matches = "1.5.0"
 # ethers-core = "2.0.8"
+ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-config = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 # ic-crypto-test-utils-reproducible-rng = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,12 @@ hex = "0.4"
 [dev-dependencies]
 # assert_matches = "1.5.0"
 # ethers-core = "2.0.8"
-ic-base-types = { path = "../../../types/base_types" }
-ic-config = { path = "../../../config" }
-ic-crypto-test-utils-reproducible-rng = { path = "../../../crypto/test_utils/reproducible_rng" }
-ic-icrc1-ledger = { path = "../../../rosetta-api/icrc1/ledger" }
-ic-state-machine-tests = { path = "../../../state_machine_tests" }
-ic-test-utilities-load-wasm = { path = "../../../test_utilities/load_wasm" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-config = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+# ic-crypto-test-utils-reproducible-rng = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+# ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 # maplit = "1"
 # proptest = "1.0"
 # rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ debug = false
 lto = true
 opt-level = 'z'
 
+[profile.canister-release]
+inherits = "release"
+
 [dependencies]
 candid = { workspace = true }
 ic-canister-log = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ debug = false
 lto = true
 opt-level = 'z'
 
+# Required by `ic-test-utilities-load-wasm`
 [profile.canister-release]
 inherits = "release"
 

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -66,7 +66,6 @@ fn get_rpc_client(source: CandidRpcSource) -> RpcResult<CkEthRpcClient<CanisterT
         })
     }
     if !is_rpc_allowed(&ic_cdk::caller()) {
-        // inc_metric!(eth_*_err_no_permission);
         return Err(ProviderError::NoPermission.into());
     }
     Ok(match source {

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -1,0 +1,174 @@
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use cketh_common::{
+    eth_rpc::{
+        into_nat, Block, FeeHistory, GetLogsParam, Hash, HttpOutcallError, JsonRpcReply, LogEntry,
+        ProviderError, RpcError, SendRawTransactionResult, ValidationError,
+    },
+    eth_rpc_client::{
+        providers::{RpcApi, RpcNodeProvider},
+        requests::GetTransactionCountParams,
+        EthRpcClient as CkEthRpcClient, MultiCallError, RpcTransport,
+    },
+    lifecycle::EthereumNetwork,
+};
+use serde::de::DeserializeOwned;
+
+use crate::*;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CanisterTransport;
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl RpcTransport for CanisterTransport {
+    fn get_subnet_size() -> u32 {
+        METADATA.with(|m| m.borrow().get().nodes_in_subnet)
+    }
+
+    fn resolve_api(provider: RpcNodeProvider) -> Result<RpcApi, ProviderError> {
+        // TODO: https://github.com/internet-computer-protocol/ic-eth-rpc/issues/73
+        Ok(provider.api())
+    }
+
+    async fn call_json_rpc<T: DeserializeOwned>(
+        provider: RpcNodeProvider,
+        json: &str,
+        max_response_bytes: u64,
+    ) -> Result<T, RpcError> {
+        let response = do_http_request(
+            ic_cdk::caller(),
+            ResolvedSource::Api(Self::resolve_api(provider)?),
+            json,
+            max_response_bytes,
+        )
+        .await
+        .unwrap();
+        let status = get_http_response_status(response.status.clone());
+        let body = get_http_response_body(response)?;
+        let json: JsonRpcReply<T> = serde_json::from_str(&body).unwrap_or_else(|e| {
+            Err(HttpOutcallError::InvalidHttpJsonRpcResponse {
+                status,
+                body,
+                parsing_error: Some(format!("JSON response parse error: {e}")),
+            })
+        })?;
+        json.result.into()
+    }
+}
+
+fn get_rpc_client(source: CandidRpcSource) -> RpcResult<CkEthRpcClient<CanisterTransport>> {
+    fn validate_providers<T>(opt_vec: Option<Vec<T>>) -> RpcResult<Option<Vec<T>>> {
+        Ok(match opt_vec {
+            Some(v) if v.is_empty() => Err(ProviderError::ProviderNotFound)?,
+            opt => opt,
+        })
+    }
+    if !is_rpc_allowed(&ic_cdk::caller()) {
+        // inc_metric!(eth_*_err_no_permission);
+        return Err(ProviderError::NoPermission.into());
+    }
+    Ok(match source {
+        CandidRpcSource::EthMainnet(service) => CkEthRpcClient::new(
+            EthereumNetwork::Ethereum,
+            validate_providers(Some(vec![service.unwrap_or(
+                cketh_common::eth_rpc_client::providers::EthereumProvider::Ankr,
+            )]))?
+            .map(|p| p.into_iter().map(RpcNodeProvider::Ethereum).collect()),
+        ),
+        CandidRpcSource::EthSepolia(service) => CkEthRpcClient::new(
+            EthereumNetwork::Sepolia,
+            validate_providers(Some(vec![service.unwrap_or(
+                cketh_common::eth_rpc_client::providers::SepoliaProvider::PublicNode,
+            )]))?
+            .map(|p| p.into_iter().map(RpcNodeProvider::Sepolia).collect()),
+        ),
+    })
+}
+
+fn wrap_result<T>(result: Result<T, MultiCallError<T>>) -> RpcResult<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(err) => match err {
+            MultiCallError::ConsistentError(err) => Err(err),
+            MultiCallError::InconsistentResults(_results) => {
+                unreachable!("BUG: receieved more than one RPC provider result")
+            }
+        },
+    }
+}
+
+pub struct CandidRpcClient {
+    client: CkEthRpcClient<CanisterTransport>,
+}
+
+impl CandidRpcClient {
+    pub fn from_source(source: CandidRpcSource) -> RpcResult<Self> {
+        Ok(Self {
+            client: get_rpc_client(source)?,
+        })
+    }
+
+    pub async fn eth_get_logs(&self, args: candid_types::GetLogsArgs) -> RpcResult<Vec<LogEntry>> {
+        let args: GetLogsParam = match args.try_into() {
+            Ok(args) => args,
+            Err(err) => return Err(RpcError::from(err)),
+        };
+        wrap_result(self.client.eth_get_logs(args).await)
+    }
+
+    pub async fn eth_get_block_by_number(
+        &self,
+        block: candid_types::BlockSpec,
+    ) -> RpcResult<Block> {
+        wrap_result(self.client.eth_get_block_by_number(block.into()).await)
+    }
+
+    pub async fn eth_get_transaction_receipt(
+        &self,
+        hash: String,
+    ) -> RpcResult<Option<candid_types::TransactionReceipt>> {
+        wrap_result(
+            self.client
+                .eth_get_transaction_receipt(
+                    Hash::from_str(&hash).map_err(|_| ValidationError::InvalidHex(hash))?,
+                )
+                .await,
+        )
+        .map(|option| option.map(|r| r.into()))
+    }
+
+    pub async fn eth_get_transaction_count(
+        &self,
+        args: candid_types::GetTransactionCountArgs,
+    ) -> RpcResult<candid::Nat> {
+        let args: GetTransactionCountParams = match args.try_into() {
+            Ok(args) => args,
+            Err(err) => return Err(RpcError::from(err)),
+        };
+        wrap_result(
+            self.client
+                .eth_get_transaction_count(args)
+                .await
+                .reduce_with_equality(),
+        )
+        .map(|count| into_nat(count.into_inner()))
+    }
+
+    pub async fn eth_fee_history(
+        &self,
+        args: candid_types::FeeHistoryArgs,
+    ) -> RpcResult<Option<FeeHistory>> {
+        wrap_result(self.client.eth_fee_history(args.into()).await).map(|history| history.into())
+    }
+
+    pub async fn eth_send_raw_transaction(
+        &self,
+        raw_signed_transaction_hex: String,
+    ) -> RpcResult<SendRawTransactionResult> {
+        self.client
+            .eth_send_raw_transaction(raw_signed_transaction_hex)
+            .await
+    }
+}

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -59,29 +59,19 @@ impl RpcTransport for CanisterTransport {
 }
 
 fn get_rpc_client(source: CandidRpcSource) -> RpcResult<CkEthRpcClient<CanisterTransport>> {
-    fn validate_providers<T>(opt_vec: Option<Vec<T>>) -> RpcResult<Option<Vec<T>>> {
-        Ok(match opt_vec {
-            Some(v) if v.is_empty() => Err(ProviderError::ProviderNotFound)?,
-            opt => opt,
-        })
-    }
     if !is_rpc_allowed(&ic_cdk::caller()) {
         return Err(ProviderError::NoPermission.into());
     }
     Ok(match source {
         CandidRpcSource::EthMainnet(service) => CkEthRpcClient::new(
             EthereumNetwork::Ethereum,
-            validate_providers(Some(vec![service.unwrap_or(
-                cketh_common::eth_rpc_client::providers::EthereumProvider::Ankr,
-            )]))?
-            .map(|p| p.into_iter().map(RpcNodeProvider::Ethereum).collect()),
+            Some(vec![service.unwrap_or(DEFAULT_ETHEREUM_PROVIDER)])
+                .map(|p| p.into_iter().map(RpcNodeProvider::Ethereum).collect()),
         ),
         CandidRpcSource::EthSepolia(service) => CkEthRpcClient::new(
             EthereumNetwork::Sepolia,
-            validate_providers(Some(vec![service.unwrap_or(
-                cketh_common::eth_rpc_client::providers::SepoliaProvider::PublicNode,
-            )]))?
-            .map(|p| p.into_iter().map(RpcNodeProvider::Sepolia).collect()),
+            Some(vec![service.unwrap_or(DEFAULT_SEPOLIA_PROVIDER)])
+                .map(|p| p.into_iter().map(RpcNodeProvider::Sepolia).collect()),
         ),
     })
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,5 @@
+use cketh_common::eth_rpc_client::providers::{EthereumProvider, SepoliaProvider};
+
 pub const INGRESS_OVERHEAD_BYTES: u128 = 100;
 pub const INGRESS_MESSAGE_RECEIVED_COST: u128 = 1_200_000;
 pub const INGRESS_MESSAGE_BYTE_RECEIVED_COST: u128 = 2_000;
@@ -12,6 +14,10 @@ pub const WASM_PAGE_SIZE: u64 = 65536;
 
 pub const DEFAULT_NODES_IN_SUBNET: u32 = 13;
 pub const DEFAULT_OPEN_RPC_ACCESS: bool = true;
+
+// Providers used by default (when passing `null` with `CandidRpcSource`)
+pub const DEFAULT_ETHEREUM_PROVIDER: EthereumProvider = EthereumProvider::Ankr;
+pub const DEFAULT_SEPOLIA_PROVIDER: SepoliaProvider = SepoliaProvider::PublicNode;
 
 pub const CONTENT_TYPE_HEADER: &str = "Content-Type";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub use candid::Principal;
 
 mod accounting;
 mod auth;
+mod candid_rpc;
 mod constants;
 mod http;
 mod memory;
@@ -14,6 +15,7 @@ mod validate;
 
 pub use crate::accounting::*;
 pub use crate::auth::*;
+pub use crate::candid_rpc::*;
 pub use crate::constants::*;
 pub use crate::http::*;
 pub use crate::memory::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,8 @@
-use std::str::FromStr;
-
-use async_trait::async_trait;
 use candid::{candid_method, CandidType};
 use cketh_common::eth_rpc::{
-    into_nat, Block, BlockSpec, FeeHistory, GetLogsParam, Hash, HttpOutcallError, JsonRpcReply,
-    LogEntry, ProviderError, RpcError, SendRawTransactionResult, ValidationError,
+    Block, FeeHistory, LogEntry, ProviderError, RpcError, SendRawTransactionResult,
 };
-use cketh_common::eth_rpc_client::providers::RpcApi;
-use cketh_common::eth_rpc_client::requests::GetTransactionCountParams;
-use cketh_common::eth_rpc_client::{providers::RpcNodeProvider, EthRpcClient};
-use cketh_common::eth_rpc_client::{MultiCallError, RpcTransport};
-use cketh_common::lifecycle::EthereumNetwork;
+
 use ic_canister_log::log;
 use ic_canisters_http_types::{
     HttpRequest as AssetHttpRequest, HttpResponse as AssetHttpResponse, HttpResponseBuilder,
@@ -20,89 +12,6 @@ use ic_cdk::{query, update};
 use ic_nervous_system_common::{serve_logs, serve_logs_v2, serve_metrics};
 
 use evm_rpc::*;
-use serde::de::DeserializeOwned;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct CanisterTransport;
-
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl RpcTransport for CanisterTransport {
-    fn get_subnet_size() -> u32 {
-        METADATA.with(|m| m.borrow().get().nodes_in_subnet)
-    }
-
-    fn resolve_api(provider: RpcNodeProvider) -> Result<RpcApi, ProviderError> {
-        // TODO: https://github.com/internet-computer-protocol/ic-eth-rpc/issues/73
-        Ok(provider.api())
-    }
-
-    async fn call_json_rpc<T: DeserializeOwned>(
-        provider: RpcNodeProvider,
-        json: &str,
-        max_response_bytes: u64,
-    ) -> Result<T, RpcError> {
-        let response = do_http_request(
-            ic_cdk::caller(),
-            ResolvedSource::Api(Self::resolve_api(provider)?),
-            json,
-            max_response_bytes,
-        )
-        .await
-        .unwrap();
-        let status = get_http_response_status(response.status.clone());
-        let body = get_http_response_body(response)?;
-        let json: JsonRpcReply<T> = serde_json::from_str(&body).unwrap_or_else(|e| {
-            Err(HttpOutcallError::InvalidHttpJsonRpcResponse {
-                status,
-                body,
-                parsing_error: Some(format!("JSON response parse error: {e}")),
-            })
-        })?;
-        json.result.into()
-    }
-}
-
-fn get_rpc_client(source: CandidRpcSource) -> Result<EthRpcClient<CanisterTransport>, RpcError> {
-    fn validate_providers<T>(opt_vec: Option<Vec<T>>) -> Result<Option<Vec<T>>, RpcError> {
-        Ok(match opt_vec {
-            Some(v) if v.is_empty() => Err(ProviderError::ProviderNotFound)?,
-            opt => opt,
-        })
-    }
-    if !is_rpc_allowed(&ic_cdk::caller()) {
-        // inc_metric!(eth_*_err_no_permission);
-        return Err(ProviderError::NoPermission.into());
-    }
-    Ok(match source {
-        CandidRpcSource::EthMainnet(service) => EthRpcClient::new(
-            EthereumNetwork::Ethereum,
-            validate_providers(Some(vec![service.unwrap_or(
-                cketh_common::eth_rpc_client::providers::EthereumProvider::Ankr,
-            )]))?
-            .map(|p| p.into_iter().map(RpcNodeProvider::Ethereum).collect()),
-        ),
-        CandidRpcSource::EthSepolia(service) => EthRpcClient::new(
-            EthereumNetwork::Sepolia,
-            validate_providers(Some(vec![service.unwrap_or(
-                cketh_common::eth_rpc_client::providers::SepoliaProvider::PublicNode,
-            )]))?
-            .map(|p| p.into_iter().map(RpcNodeProvider::Sepolia).collect()),
-        ),
-    })
-}
-
-fn wrap_result<T>(result: Result<T, MultiCallError<T>>) -> RpcResult<T> {
-    match result {
-        Ok(value) => Ok(value),
-        Err(err) => match err {
-            MultiCallError::ConsistentError(err) => Err(err),
-            MultiCallError::InconsistentResults(_results) => {
-                unreachable!("BUG: receieved more than one RPC provider result")
-            }
-        },
-    }
-}
 
 #[ic_cdk_macros::update]
 #[candid_method]
@@ -110,12 +19,9 @@ pub async fn eth_get_logs(
     source: CandidRpcSource,
     args: candid_types::GetLogsArgs,
 ) -> RpcResult<Vec<LogEntry>> {
-    let args: GetLogsParam = match args.try_into() {
-        Ok(args) => args,
-        Err(err) => return Err(RpcError::from(err)),
-    };
-    let client = get_rpc_client(source)?;
-    wrap_result(client.eth_get_logs(args).await)
+    CandidRpcClient::from_source(source)?
+        .eth_get_logs(args)
+        .await
 }
 
 #[ic_cdk_macros::update]
@@ -124,9 +30,9 @@ pub async fn eth_get_block_by_number(
     source: CandidRpcSource,
     block: candid_types::BlockSpec,
 ) -> RpcResult<Block> {
-    let block: BlockSpec = block.into();
-    let client = get_rpc_client(source)?;
-    wrap_result(client.eth_get_block_by_number(block).await)
+    CandidRpcClient::from_source(source)?
+        .eth_get_block_by_number(block)
+        .await
 }
 
 #[ic_cdk_macros::update]
@@ -135,15 +41,9 @@ pub async fn eth_get_transaction_receipt(
     source: CandidRpcSource,
     hash: String,
 ) -> RpcResult<Option<candid_types::TransactionReceipt>> {
-    let client = get_rpc_client(source)?;
-    wrap_result(
-        client
-            .eth_get_transaction_receipt(
-                Hash::from_str(&hash).map_err(|_| ValidationError::InvalidHex(hash))?,
-            )
-            .await,
-    )
-    .map(|option| option.map(|r| r.into()))
+    CandidRpcClient::from_source(source)?
+        .eth_get_transaction_receipt(hash)
+        .await
 }
 
 #[ic_cdk_macros::update]
@@ -152,18 +52,9 @@ pub async fn eth_get_transaction_count(
     source: CandidRpcSource,
     args: candid_types::GetTransactionCountArgs,
 ) -> RpcResult<candid::Nat> {
-    let args: GetTransactionCountParams = match args.try_into() {
-        Ok(args) => args,
-        Err(err) => return Err(RpcError::from(err)),
-    };
-    let client = get_rpc_client(source)?;
-    wrap_result(
-        client
-            .eth_get_transaction_count(args)
-            .await
-            .reduce_with_equality(),
-    )
-    .map(|count| into_nat(count.into_inner()))
+    CandidRpcClient::from_source(source)?
+        .eth_get_transaction_count(args)
+        .await
 }
 
 #[ic_cdk_macros::update]
@@ -172,9 +63,9 @@ pub async fn eth_fee_history(
     source: CandidRpcSource,
     args: candid_types::FeeHistoryArgs,
 ) -> RpcResult<Option<FeeHistory>> {
-    let args = args.into();
-    let client = get_rpc_client(source)?;
-    wrap_result(client.eth_fee_history(args).await).map(|history| history.into())
+    CandidRpcClient::from_source(source)?
+        .eth_fee_history(args)
+        .await
 }
 
 #[ic_cdk_macros::update]
@@ -183,8 +74,7 @@ pub async fn eth_send_raw_transaction(
     source: CandidRpcSource,
     raw_signed_transaction_hex: String,
 ) -> RpcResult<SendRawTransactionResult> {
-    let client = get_rpc_client(source)?;
-    client
+    CandidRpcClient::from_source(source)?
         .eth_send_raw_transaction(raw_signed_transaction_hex)
         .await
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -197,7 +197,7 @@ impl BoundedStorable for PrincipalStorable {
     const IS_FIXED_SIZE: bool = false;
 }
 
-#[derive(Clone, Debug, CandidType, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]
 pub struct ProviderView {
     pub provider_id: u64,
     pub owner: Principal,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,11 +1,25 @@
 use cketh_common::eth_rpc_client::providers::SepoliaProvider;
-use evm_rpc::{CandidRpcClient, CandidRpcSource};
+use evm_rpc::{Auth, CandidRpcClient, CandidRpcSource};
+
+const DEFAULT_CALLER_ID: u64 = 10352385;
+
+fn evm_rpc_wasm() -> Vec<u8> {
+    load_wasm(std::env::var("CARGO_MANIFEST_DIR").unwrap(), "evm_rpc", &[])
+}
+
+fn assert_reply(result: WasmResult) -> Vec<u8> {
+    match result {
+        WasmResult::Reply(bytes) => bytes,
+        result => {
+            panic!("Expected a successful reply, got {}", reject)
+        }
+    }
+}
 
 pub struct EvmRpcSetup {
     pub env: StateMachine,
     pub caller: PrincipalId,
-    pub ledger_id: CanisterId,
-    pub minter_id: CanisterId,
+    pub evm_rpc_id: CanisterId,
 }
 
 impl Default for EvmRpcSetup {
@@ -19,283 +33,264 @@ impl EvmRpcSetup {
         let env = StateMachineBuilder::new()
             .with_default_canister_range()
             .build();
-        let minter_id =
-            env.create_canister_with_cycles(None, Cycles::new(100_000_000_000_000), None);
-        let ledger_id = env.create_canister(None);
 
-        env.install_existing_canister(
-            ledger_id,
-            ledger_wasm(),
-            Encode!(&LedgerArgument::Init(
-                LedgerInitArgsBuilder::with_symbol_and_name("ckETH", "ckETH")
-                    .with_minting_account(minter_id.get().0)
-                    .with_transfer_fee(CKETH_TRANSFER_FEE)
-                    .with_max_memo_length(80)
-                    .with_decimals(18)
-                    .with_feature_flags(ic_icrc1_ledger::FeatureFlags { icrc2: true })
-                    .build(),
-            ))
-            .unwrap(),
-        )
-        .unwrap();
-        let minter_id = install_minter(&env, ledger_id, minter_id);
-        let caller = PrincipalId::new_user_test_id(DEFAULT_PRINCIPAL_ID);
+        let evm_rpc_id = env.create_canister(None);
+        env.install_existing_canister(evm_rpc_id, evm_rpc_wasm(), Encode!(&()).unwrap())
+            .unwrap();
 
-        let cketh = Self {
+        let caller = PrincipalId::new_user_test_id(DEFAULT_CALLER_ID);
+
+        Self {
             env,
             caller,
-            ledger_id,
-            minter_id,
-        };
-
-        assert_eq!(
-            Address::from_str(MINTER_ADDRESS).unwrap(),
-            Address::from_str(&cketh.minter_address()).unwrap()
-        );
-        cketh
-    }
-
-    pub fn deposit(self, params: DepositParams) -> DepositFlow {
-        DepositFlow {
-            setup: self,
-            params,
+            evm_rpc_id,
         }
     }
 
-    pub fn minter_address(&self) -> String {
+    // pub fn deposit(self, params: DepositParams) -> DepositFlow {
+    //     DepositFlow {
+    //         setup: self,
+    //         params,
+    //     }
+    // }
+
+    pub fn call_update<T, R>(&self, method: &str, input: &T) -> R {
         Decode!(
             &assert_reply(
                 self.env
                     .execute_ingress_as(
                         self.caller,
-                        self.minter_id,
-                        "minter_address",
-                        Encode!().unwrap(),
+                        self.evm_rpc_id,
+                        method,
+                        Encode!(input).unwrap(),
                     )
-                    .expect("failed to get eth address")
+                    .expect("error during update call")
             ),
-            String
+            T
         )
         .unwrap()
     }
 
-    pub fn retrieve_eth_status(&self, block_index: &Nat) -> RetrieveEthStatus {
+    pub fn call_query<T, R>(&self, method: &str, input: T) -> R {
         Decode!(
             &assert_reply(
                 self.env
-                    .execute_ingress_as(
+                    .query_as(
                         self.caller,
-                        self.minter_id,
-                        "retrieve_eth_status",
-                        Encode!(&block_index.0.to_u64().unwrap()).unwrap(),
+                        self.evm_rpc_id,
+                        method,
+                        Encode!(input).unwrap(),
                     )
-                    .expect("failed to get eth address")
+                    .expect("error during query call")
             ),
-            RetrieveEthStatus
+            R
         )
         .unwrap()
     }
 
-    pub fn balance_of(&self, account: impl Into<Account>) -> Nat {
-        Decode!(
-            &assert_reply(
-                self.env
-                    .query(
-                        self.ledger_id,
-                        "icrc1_balance_of",
-                        Encode!(&account.into()).unwrap()
-                    )
-                    .expect("failed to query balance on the ledger")
-            ),
-            Nat
-        )
-        .unwrap()
-    }
-
-    pub fn call_ledger_approve_minter(
-        self,
-        from: Principal,
-        amount: u64,
-        from_subaccount: Option<[u8; 32]>,
-    ) -> ApprovalFlow {
-        let approval_response = Decode!(&assert_reply(self.env.execute_ingress_as(
-            PrincipalId::from(from),
-            self.ledger_id,
-            "icrc2_approve",
-            Encode!(&ApproveArgs {
-                from_subaccount,
-                spender: Account {
-                    owner: self.minter_id.into(),
-                    subaccount: None
-                },
-                amount: Nat::from(amount),
-                expected_allowance: None,
-                expires_at: None,
-                fee: None,
-                memo: None,
-                created_at_time: None,
-            }).unwrap()
-            ).expect("failed to execute token transfer")),
-            Result<Nat, ApproveError>
-        )
-        .unwrap();
-        ApprovalFlow {
-            setup: self,
-            approval_response,
-        }
-    }
-
-    pub fn call_minter_withdraw_eth(
-        self,
-        from: Principal,
-        amount: Nat,
-        recipient: String,
-    ) -> WithdrawalFlow {
-        let arg = WithdrawalArg { amount, recipient };
-        let message_id = self.env.send_ingress(
-            PrincipalId::from(from),
-            self.minter_id,
-            "withdraw_eth",
-            Encode!(&arg).expect("failed to encode withdraw args"),
-        );
-        WithdrawalFlow {
-            setup: self,
-            message_id,
-        }
-    }
-
-    pub fn _get_logs(&self, priority: &str) -> Log {
-        let request = HttpRequest {
-            method: "".to_string(),
-            url: format!("/logs?priority={priority}"),
-            headers: vec![],
-            body: serde_bytes::ByteBuf::new(),
-        };
-        let response = Decode!(
-            &assert_reply(
-                self.env
-                    .query(self.minter_id, "http_request", Encode!(&request).unwrap(),)
-                    .expect("failed to get minter info")
-            ),
-            HttpResponse
-        )
-        .unwrap();
-        serde_json::from_slice(&response.body).expect("failed to parse ckbtc minter log")
-    }
-
-    pub fn assert_has_unique_events_in_order(self, expected_events: &[EventPayload]) -> Self {
-        let audit_events = self.get_all_events();
-        let mut found_event_indexes = BTreeMap::new();
-        for (index_expected_event, expected_event) in expected_events.iter().enumerate() {
-            for (index_audit_event, audit_event) in audit_events.iter().enumerate() {
-                if &audit_event.payload == expected_event {
-                    assert_eq!(
-                        found_event_indexes.insert(index_expected_event, index_audit_event),
-                        None,
-                        "Event {:?} occurs multiple times",
-                        expected_event
-                    );
-                }
-            }
-            assert!(
-                found_event_indexes.contains_key(&index_expected_event),
-                "Missing event {:?}",
-                expected_event
-            )
-        }
-        let audit_event_indexes = found_event_indexes.into_values().collect::<Vec<_>>();
-        let sorted_audit_event_indexes = {
-            let mut indexes = audit_event_indexes.clone();
-            indexes.sort_unstable();
-            indexes
-        };
-        assert_eq!(
-            audit_event_indexes, sorted_audit_event_indexes,
-            "Events were found in unexpected order"
-        );
+    pub fn authorize(self, auth: Auth) -> Self {
+        assert!(self.call_update("authorize", ()));
         self
     }
 
-    pub fn assert_has_no_event_satisfying<P: Fn(&EventPayload) -> bool>(
-        self,
-        predicate: P,
-    ) -> Self {
-        if let Some(unexpected_event) = self
-            .get_all_events()
-            .into_iter()
-            .find(|event| predicate(&event.payload))
-        {
-            panic!(
-                "Found an event satisfying the predicate: {:?}",
-                unexpected_event
-            )
-        }
-        self
-    }
-
-    fn get_events(&self, start: u64, length: u64) -> GetEventsResult {
-        use ic_cketh_minter::endpoints::events::GetEventsArg;
-
-        Decode!(
-            &assert_reply(
-                self.env
-                    .execute_ingress(
-                        self.minter_id,
-                        "get_events",
-                        Encode!(&GetEventsArg { start, length }).unwrap(),
-                    )
-                    .expect("failed to get minter info")
-            ),
-            GetEventsResult
+    pub fn request_cost(
+        &self,
+        source: Source,
+        json_rpc_payload: &str,
+        max_response_bytes: u64,
+    ) -> Nat {
+        self.call_query(
+            "request_cost",
+            (source, json_rpc_payload, max_response_bytes),
         )
-        .unwrap()
     }
 
-    pub fn get_all_events(&self) -> Vec<Event> {
-        const FIRST_BATCH_SIZE: u64 = 100;
-        let GetEventsResult {
-            mut events,
-            total_event_count,
-        } = self.get_events(0, FIRST_BATCH_SIZE);
-        while events.len() < total_event_count as usize {
-            let mut next_batch =
-                self.get_events(events.len() as u64, total_event_count - events.len() as u64);
-            events.append(&mut next_batch.events);
-        }
-        events
-    }
+    // pub fn call_ledger_approve_minter(
+    //     self,
+    //     from: Principal,
+    //     amount: u64,
+    //     from_subaccount: Option<[u8; 32]>,
+    // ) -> ApprovalFlow {
+    //     let approval_response = Decode!(&assert_reply(self.env.execute_ingress_as(
+    //         PrincipalId::from(from),
+    //         self.ledger_id,
+    //         "icrc2_approve",
+    //         Encode!(&ApproveArgs {
+    //             from_subaccount,
+    //             spender: Account {
+    //                 owner: self.minter_id.into(),
+    //                 subaccount: None
+    //             },
+    //             amount: Nat::from(amount),
+    //             expected_allowance: None,
+    //             expires_at: None,
+    //             fee: None,
+    //             memo: None,
+    //             created_at_time: None,
+    //         }).unwrap()
+    //         ).expect("failed to execute token transfer")),
+    //         Result<Nat, ApproveError>
+    //     )
+    //     .unwrap();
+    //     ApprovalFlow {
+    //         setup: self,
+    //         approval_response,
+    //     }
+    // }
 
-    fn check_audit_log(&self) {
-        Decode!(
-            &assert_reply(
-                self.env
-                    .query(self.minter_id, "check_audit_log", Encode!().unwrap())
-                    .unwrap(),
-            ),
-            ()
-        )
-        .unwrap()
-    }
+    // pub fn call_minter_withdraw_eth(
+    //     self,
+    //     from: Principal,
+    //     amount: Nat,
+    //     recipient: String,
+    // ) -> WithdrawalFlow {
+    //     let arg = WithdrawalArg { amount, recipient };
+    //     let message_id = self.env.send_ingress(
+    //         PrincipalId::from(from),
+    //         self.minter_id,
+    //         "withdraw_eth",
+    //         Encode!(&arg).expect("failed to encode withdraw args"),
+    //     );
+    //     WithdrawalFlow {
+    //         setup: self,
+    //         message_id,
+    //     }
+    // }
 
-    fn upgrade_minter(&self) {
-        self.env
-            .upgrade_canister(
-                self.minter_id,
-                minter_wasm(),
-                Encode!(&MinterArg::UpgradeArg(Default::default())).unwrap(),
-            )
-            .unwrap();
-    }
+    // pub fn _get_logs(&self, priority: &str) -> Log {
+    //     let request = HttpRequest {
+    //         method: "".to_string(),
+    //         url: format!("/logs?priority={priority}"),
+    //         headers: vec![],
+    //         body: serde_bytes::ByteBuf::new(),
+    //     };
+    //     let response = Decode!(
+    //         &assert_reply(
+    //             self.env
+    //                 .query(self.minter_id, "http_request", Encode!(&request).unwrap(),)
+    //                 .expect("failed to get minter info")
+    //         ),
+    //         HttpResponse
+    //     )
+    //     .unwrap();
+    //     serde_json::from_slice(&response.body).expect("failed to parse ckbtc minter log")
+    // }
 
-    fn check_audit_logs_and_upgrade(self) -> Self {
-        self.check_audit_log();
-        self.env.tick(); //tick before upgrade to finish current timers which are reset afterwards
-        self.upgrade_minter();
-        self
-    }
+    // pub fn assert_has_unique_events_in_order(self, expected_events: &[EventPayload]) -> Self {
+    //     let audit_events = self.get_all_events();
+    //     let mut found_event_indexes = BTreeMap::new();
+    //     for (index_expected_event, expected_event) in expected_events.iter().enumerate() {
+    //         for (index_audit_event, audit_event) in audit_events.iter().enumerate() {
+    //             if &audit_event.payload == expected_event {
+    //                 assert_eq!(
+    //                     found_event_indexes.insert(index_expected_event, index_audit_event),
+    //                     None,
+    //                     "Event {:?} occurs multiple times",
+    //                     expected_event
+    //                 );
+    //             }
+    //         }
+    //         assert!(
+    //             found_event_indexes.contains_key(&index_expected_event),
+    //             "Missing event {:?}",
+    //             expected_event
+    //         )
+    //     }
+    //     let audit_event_indexes = found_event_indexes.into_values().collect::<Vec<_>>();
+    //     let sorted_audit_event_indexes = {
+    //         let mut indexes = audit_event_indexes.clone();
+    //         indexes.sort_unstable();
+    //         indexes
+    //     };
+    //     assert_eq!(
+    //         audit_event_indexes, sorted_audit_event_indexes,
+    //         "Events were found in unexpected order"
+    //     );
+    //     self
+    // }
+
+    // pub fn assert_has_no_event_satisfying<P: Fn(&EventPayload) -> bool>(
+    //     self,
+    //     predicate: P,
+    // ) -> Self {
+    //     if let Some(unexpected_event) = self
+    //         .get_all_events()
+    //         .into_iter()
+    //         .find(|event| predicate(&event.payload))
+    //     {
+    //         panic!(
+    //             "Found an event satisfying the predicate: {:?}",
+    //             unexpected_event
+    //         )
+    //     }
+    //     self
+    // }
+
+    // fn get_events(&self, start: u64, length: u64) -> GetEventsResult {
+    //     use ic_cketh_minter::endpoints::events::GetEventsArg;
+
+    //     Decode!(
+    //         &assert_reply(
+    //             self.env
+    //                 .execute_ingress(
+    //                     self.minter_id,
+    //                     "get_events",
+    //                     Encode!(&GetEventsArg { start, length }).unwrap(),
+    //                 )
+    //                 .expect("failed to get minter info")
+    //         ),
+    //         GetEventsResult
+    //     )
+    //     .unwrap()
+    // }
+
+    // pub fn get_all_events(&self) -> Vec<Event> {
+    //     const FIRST_BATCH_SIZE: u64 = 100;
+    //     let GetEventsResult {
+    //         mut events,
+    //         total_event_count,
+    //     } = self.get_events(0, FIRST_BATCH_SIZE);
+    //     while events.len() < total_event_count as usize {
+    //         let mut next_batch =
+    //             self.get_events(events.len() as u64, total_event_count - events.len() as u64);
+    //         events.append(&mut next_batch.events);
+    //     }
+    //     events
+    // }
+
+    // fn check_audit_log(&self) {
+    //     Decode!(
+    //         &assert_reply(
+    //             self.env
+    //                 .query(self.minter_id, "check_audit_log", Encode!().unwrap())
+    //                 .unwrap(),
+    //         ),
+    //         ()
+    //     )
+    //     .unwrap()
+    // }
+
+    // fn upgrade_minter(&self) {
+    //     self.env
+    //         .upgrade_canister(
+    //             self.minter_id,
+    //             minter_wasm(),
+    //             Encode!(&MinterArg::UpgradeArg(Default::default())).unwrap(),
+    //         )
+    //         .unwrap();
+    // }
+
+    // fn check_audit_logs_and_upgrade(self) -> Self {
+    //     self.check_audit_log();
+    //     self.env.tick(); //tick before upgrade to finish current timers which are reset afterwards
+    //     self.upgrade_minter();
+    //     self
+    // }
 }
 
 #[test]
-fn test_eth_get_logs() {
-    let mainnet = CandidRpcClient::from_source(CandidRpcSource::EthMainnet(None));
+fn test_register_provider() {
+    let setup = EvmRpcSetup::new().authorize(Auth::RegisterProvider);
+
+    // assert!(false);
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -121,6 +121,14 @@ impl EvmRpcSetup {
         self.call_update("deauthorize", Encode!(&principal.0, &auth).unwrap())
     }
 
+    pub fn get_providers(&self) -> Vec<ProviderView> {
+        self.call_update("get_providers", Encode!().unwrap())
+    }
+
+    pub fn register_provider(&self, args: RegisterProviderArgs) -> u64 {
+        self.call_update("register_provider", Encode!(&args).unwrap())
+    }
+
     pub fn authorize_caller(self, auth: Auth) -> Self {
         self.as_controller().authorize(&self.caller, auth);
         self
@@ -142,203 +150,51 @@ impl EvmRpcSetup {
             Encode!(&source, &json_rpc_payload, &max_response_bytes).unwrap(),
         )
     }
-
-    // pub fn deposit(self, params: DepositParams) -> DepositFlow {
-    //     DepositFlow {
-    //         setup: self,
-    //         params,
-    //     }
-    // }
-
-    // pub fn call_ledger_approve_minter(
-    //     self,
-    //     from: Principal,
-    //     amount: u64,
-    //     from_subaccount: Option<[u8; 32]>,
-    // ) -> ApprovalFlow {
-    //     let approval_response = Decode!(&assert_reply(self.env.execute_ingress_as(
-    //         PrincipalId::from(from),
-    //         self.ledger_id,
-    //         "icrc2_approve",
-    //         Encode!(&ApproveArgs {
-    //             from_subaccount,
-    //             spender: Account {
-    //                 owner: self.minter_id.into(),
-    //                 subaccount: None
-    //             },
-    //             amount: Nat::from(amount),
-    //             expected_allowance: None,
-    //             expires_at: None,
-    //             fee: None,
-    //             memo: None,
-    //             created_at_time: None,
-    //         }).unwrap()
-    //         ).expect("failed to execute token transfer")),
-    //         Result<Nat, ApproveError>
-    //     )
-    //     .unwrap();
-    //     ApprovalFlow {
-    //         setup: self,
-    //         approval_response,
-    //     }
-    // }
-
-    // pub fn call_minter_withdraw_eth(
-    //     self,
-    //     from: Principal,
-    //     amount: Nat,
-    //     recipient: String,
-    // ) -> WithdrawalFlow {
-    //     let arg = WithdrawalArg { amount, recipient };
-    //     let message_id = self.env.send_ingress(
-    //         PrincipalId::from(from),
-    //         self.minter_id,
-    //         "withdraw_eth",
-    //         Encode!(&arg).expect("failed to encode withdraw args"),
-    //     );
-    //     WithdrawalFlow {
-    //         setup: self,
-    //         message_id,
-    //     }
-    // }
-
-    // pub fn _get_logs(&self, priority: &str) -> Log {
-    //     let request = HttpRequest {
-    //         method: "".to_string(),
-    //         url: format!("/logs?priority={priority}"),
-    //         headers: vec![],
-    //         body: serde_bytes::ByteBuf::new(),
-    //     };
-    //     let response = Decode!(
-    //         &assert_reply(
-    //             self.env
-    //                 .query(self.minter_id, "http_request", Encode!(&request).unwrap(),)
-    //                 .expect("failed to get minter info")
-    //         ),
-    //         HttpResponse
-    //     )
-    //     .unwrap();
-    //     serde_json::from_slice(&response.body).expect("failed to parse ckbtc minter log")
-    // }
-
-    // pub fn assert_has_unique_events_in_order(self, expected_events: &[EventPayload]) -> Self {
-    //     let audit_events = self.get_all_events();
-    //     let mut found_event_indexes = BTreeMap::new();
-    //     for (index_expected_event, expected_event) in expected_events.iter().enumerate() {
-    //         for (index_audit_event, audit_event) in audit_events.iter().enumerate() {
-    //             if &audit_event.payload == expected_event {
-    //                 assert_eq!(
-    //                     found_event_indexes.insert(index_expected_event, index_audit_event),
-    //                     None,
-    //                     "Event {:?} occurs multiple times",
-    //                     expected_event
-    //                 );
-    //             }
-    //         }
-    //         assert!(
-    //             found_event_indexes.contains_key(&index_expected_event),
-    //             "Missing event {:?}",
-    //             expected_event
-    //         )
-    //     }
-    //     let audit_event_indexes = found_event_indexes.into_values().collect::<Vec<_>>();
-    //     let sorted_audit_event_indexes = {
-    //         let mut indexes = audit_event_indexes.clone();
-    //         indexes.sort_unstable();
-    //         indexes
-    //     };
-    //     assert_eq!(
-    //         audit_event_indexes, sorted_audit_event_indexes,
-    //         "Events were found in unexpected order"
-    //     );
-    //     self
-    // }
-
-    // pub fn assert_has_no_event_satisfying<P: Fn(&EventPayload) -> bool>(
-    //     self,
-    //     predicate: P,
-    // ) -> Self {
-    //     if let Some(unexpected_event) = self
-    //         .get_all_events()
-    //         .into_iter()
-    //         .find(|event| predicate(&event.payload))
-    //     {
-    //         panic!(
-    //             "Found an event satisfying the predicate: {:?}",
-    //             unexpected_event
-    //         )
-    //     }
-    //     self
-    // }
-
-    // fn get_events(&self, start: u64, length: u64) -> GetEventsResult {
-    //     use ic_cketh_minter::endpoints::events::GetEventsArg;
-
-    //     Decode!(
-    //         &assert_reply(
-    //             self.env
-    //                 .execute_ingress(
-    //                     self.minter_id,
-    //                     "get_events",
-    //                     Encode!(&GetEventsArg { start, length }).unwrap(),
-    //                 )
-    //                 .expect("failed to get minter info")
-    //         ),
-    //         GetEventsResult
-    //     )
-    //     .unwrap()
-    // }
-
-    // pub fn get_all_events(&self) -> Vec<Event> {
-    //     const FIRST_BATCH_SIZE: u64 = 100;
-    //     let GetEventsResult {
-    //         mut events,
-    //         total_event_count,
-    //     } = self.get_events(0, FIRST_BATCH_SIZE);
-    //     while events.len() < total_event_count as usize {
-    //         let mut next_batch =
-    //             self.get_events(events.len() as u64, total_event_count - events.len() as u64);
-    //         events.append(&mut next_batch.events);
-    //     }
-    //     events
-    // }
-
-    // fn check_audit_log(&self) {
-    //     Decode!(
-    //         &assert_reply(
-    //             self.env
-    //                 .query(self.minter_id, "check_audit_log", Encode!().unwrap())
-    //                 .unwrap(),
-    //         ),
-    //         ()
-    //     )
-    //     .unwrap()
-    // }
-
-    // fn upgrade_minter(&self) {
-    //     self.env
-    //         .upgrade_canister(
-    //             self.minter_id,
-    //             minter_wasm(),
-    //             Encode!(&MinterArg::UpgradeArg(Default::default())).unwrap(),
-    //         )
-    //         .unwrap();
-    // }
-
-    // fn check_audit_logs_and_upgrade(self) -> Self {
-    //     self.check_audit_log();
-    //     self.env.tick(); //tick before upgrade to finish current timers which are reset afterwards
-    //     self.upgrade_minter();
-    //     self
-    // }
 }
 
 #[test]
-fn test_authorize() {
-    let setup = EvmRpcSetup::new();
-    setup
-        .as_controller()
-        .authorize_caller(Auth::RegisterProvider);
+fn test_register_provider() {
+    let setup = EvmRpcSetup::new().authorize_caller(Auth::RegisterProvider);
 
-    assert!(true);
+    let a_id = setup.register_provider(RegisterProviderArgs {
+        chain_id: 1,
+        hostname: "cloudflare-eth.com".to_string(),
+        credential_path: "".to_string(),
+        credential_headers: None,
+        cycles_per_call: 0,
+        cycles_per_message_byte: 0,
+    });
+    let b_id = setup.register_provider(RegisterProviderArgs {
+        chain_id: 5,
+        hostname: "ethereum.publicnode.com".to_string(),
+        credential_path: "".to_string(),
+        credential_headers: None,
+        cycles_per_call: 0,
+        cycles_per_message_byte: 0,
+    });
+    assert_eq!(a_id + 1, b_id);
+    let providers = setup.get_providers();
+    assert_eq!(
+        providers[providers.len() - 2..],
+        vec![
+            ProviderView {
+                provider_id: 3,
+                owner: setup.caller.0,
+                chain_id: 1,
+                hostname: "cloudflare-eth.com".to_string(),
+                cycles_per_call: 0,
+                cycles_per_message_byte: 0,
+                primary: false,
+            },
+            ProviderView {
+                provider_id: 4,
+                owner: setup.caller.0,
+                chain_id: 5,
+                hostname: "ethereum.publicnode.com".to_string(),
+                cycles_per_call: 0,
+                cycles_per_message_byte: 0,
+                primary: false,
+            }
+        ]
+    )
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,0 +1,301 @@
+use cketh_common::eth_rpc_client::providers::SepoliaProvider;
+use evm_rpc::{CandidRpcClient, CandidRpcSource};
+
+pub struct EvmRpcSetup {
+    pub env: StateMachine,
+    pub caller: PrincipalId,
+    pub ledger_id: CanisterId,
+    pub minter_id: CanisterId,
+}
+
+impl Default for EvmRpcSetup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EvmRpcSetup {
+    pub fn new() -> Self {
+        let env = StateMachineBuilder::new()
+            .with_default_canister_range()
+            .build();
+        let minter_id =
+            env.create_canister_with_cycles(None, Cycles::new(100_000_000_000_000), None);
+        let ledger_id = env.create_canister(None);
+
+        env.install_existing_canister(
+            ledger_id,
+            ledger_wasm(),
+            Encode!(&LedgerArgument::Init(
+                LedgerInitArgsBuilder::with_symbol_and_name("ckETH", "ckETH")
+                    .with_minting_account(minter_id.get().0)
+                    .with_transfer_fee(CKETH_TRANSFER_FEE)
+                    .with_max_memo_length(80)
+                    .with_decimals(18)
+                    .with_feature_flags(ic_icrc1_ledger::FeatureFlags { icrc2: true })
+                    .build(),
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        let minter_id = install_minter(&env, ledger_id, minter_id);
+        let caller = PrincipalId::new_user_test_id(DEFAULT_PRINCIPAL_ID);
+
+        let cketh = Self {
+            env,
+            caller,
+            ledger_id,
+            minter_id,
+        };
+
+        assert_eq!(
+            Address::from_str(MINTER_ADDRESS).unwrap(),
+            Address::from_str(&cketh.minter_address()).unwrap()
+        );
+        cketh
+    }
+
+    pub fn deposit(self, params: DepositParams) -> DepositFlow {
+        DepositFlow {
+            setup: self,
+            params,
+        }
+    }
+
+    pub fn minter_address(&self) -> String {
+        Decode!(
+            &assert_reply(
+                self.env
+                    .execute_ingress_as(
+                        self.caller,
+                        self.minter_id,
+                        "minter_address",
+                        Encode!().unwrap(),
+                    )
+                    .expect("failed to get eth address")
+            ),
+            String
+        )
+        .unwrap()
+    }
+
+    pub fn retrieve_eth_status(&self, block_index: &Nat) -> RetrieveEthStatus {
+        Decode!(
+            &assert_reply(
+                self.env
+                    .execute_ingress_as(
+                        self.caller,
+                        self.minter_id,
+                        "retrieve_eth_status",
+                        Encode!(&block_index.0.to_u64().unwrap()).unwrap(),
+                    )
+                    .expect("failed to get eth address")
+            ),
+            RetrieveEthStatus
+        )
+        .unwrap()
+    }
+
+    pub fn balance_of(&self, account: impl Into<Account>) -> Nat {
+        Decode!(
+            &assert_reply(
+                self.env
+                    .query(
+                        self.ledger_id,
+                        "icrc1_balance_of",
+                        Encode!(&account.into()).unwrap()
+                    )
+                    .expect("failed to query balance on the ledger")
+            ),
+            Nat
+        )
+        .unwrap()
+    }
+
+    pub fn call_ledger_approve_minter(
+        self,
+        from: Principal,
+        amount: u64,
+        from_subaccount: Option<[u8; 32]>,
+    ) -> ApprovalFlow {
+        let approval_response = Decode!(&assert_reply(self.env.execute_ingress_as(
+            PrincipalId::from(from),
+            self.ledger_id,
+            "icrc2_approve",
+            Encode!(&ApproveArgs {
+                from_subaccount,
+                spender: Account {
+                    owner: self.minter_id.into(),
+                    subaccount: None
+                },
+                amount: Nat::from(amount),
+                expected_allowance: None,
+                expires_at: None,
+                fee: None,
+                memo: None,
+                created_at_time: None,
+            }).unwrap()
+            ).expect("failed to execute token transfer")),
+            Result<Nat, ApproveError>
+        )
+        .unwrap();
+        ApprovalFlow {
+            setup: self,
+            approval_response,
+        }
+    }
+
+    pub fn call_minter_withdraw_eth(
+        self,
+        from: Principal,
+        amount: Nat,
+        recipient: String,
+    ) -> WithdrawalFlow {
+        let arg = WithdrawalArg { amount, recipient };
+        let message_id = self.env.send_ingress(
+            PrincipalId::from(from),
+            self.minter_id,
+            "withdraw_eth",
+            Encode!(&arg).expect("failed to encode withdraw args"),
+        );
+        WithdrawalFlow {
+            setup: self,
+            message_id,
+        }
+    }
+
+    pub fn _get_logs(&self, priority: &str) -> Log {
+        let request = HttpRequest {
+            method: "".to_string(),
+            url: format!("/logs?priority={priority}"),
+            headers: vec![],
+            body: serde_bytes::ByteBuf::new(),
+        };
+        let response = Decode!(
+            &assert_reply(
+                self.env
+                    .query(self.minter_id, "http_request", Encode!(&request).unwrap(),)
+                    .expect("failed to get minter info")
+            ),
+            HttpResponse
+        )
+        .unwrap();
+        serde_json::from_slice(&response.body).expect("failed to parse ckbtc minter log")
+    }
+
+    pub fn assert_has_unique_events_in_order(self, expected_events: &[EventPayload]) -> Self {
+        let audit_events = self.get_all_events();
+        let mut found_event_indexes = BTreeMap::new();
+        for (index_expected_event, expected_event) in expected_events.iter().enumerate() {
+            for (index_audit_event, audit_event) in audit_events.iter().enumerate() {
+                if &audit_event.payload == expected_event {
+                    assert_eq!(
+                        found_event_indexes.insert(index_expected_event, index_audit_event),
+                        None,
+                        "Event {:?} occurs multiple times",
+                        expected_event
+                    );
+                }
+            }
+            assert!(
+                found_event_indexes.contains_key(&index_expected_event),
+                "Missing event {:?}",
+                expected_event
+            )
+        }
+        let audit_event_indexes = found_event_indexes.into_values().collect::<Vec<_>>();
+        let sorted_audit_event_indexes = {
+            let mut indexes = audit_event_indexes.clone();
+            indexes.sort_unstable();
+            indexes
+        };
+        assert_eq!(
+            audit_event_indexes, sorted_audit_event_indexes,
+            "Events were found in unexpected order"
+        );
+        self
+    }
+
+    pub fn assert_has_no_event_satisfying<P: Fn(&EventPayload) -> bool>(
+        self,
+        predicate: P,
+    ) -> Self {
+        if let Some(unexpected_event) = self
+            .get_all_events()
+            .into_iter()
+            .find(|event| predicate(&event.payload))
+        {
+            panic!(
+                "Found an event satisfying the predicate: {:?}",
+                unexpected_event
+            )
+        }
+        self
+    }
+
+    fn get_events(&self, start: u64, length: u64) -> GetEventsResult {
+        use ic_cketh_minter::endpoints::events::GetEventsArg;
+
+        Decode!(
+            &assert_reply(
+                self.env
+                    .execute_ingress(
+                        self.minter_id,
+                        "get_events",
+                        Encode!(&GetEventsArg { start, length }).unwrap(),
+                    )
+                    .expect("failed to get minter info")
+            ),
+            GetEventsResult
+        )
+        .unwrap()
+    }
+
+    pub fn get_all_events(&self) -> Vec<Event> {
+        const FIRST_BATCH_SIZE: u64 = 100;
+        let GetEventsResult {
+            mut events,
+            total_event_count,
+        } = self.get_events(0, FIRST_BATCH_SIZE);
+        while events.len() < total_event_count as usize {
+            let mut next_batch =
+                self.get_events(events.len() as u64, total_event_count - events.len() as u64);
+            events.append(&mut next_batch.events);
+        }
+        events
+    }
+
+    fn check_audit_log(&self) {
+        Decode!(
+            &assert_reply(
+                self.env
+                    .query(self.minter_id, "check_audit_log", Encode!().unwrap())
+                    .unwrap(),
+            ),
+            ()
+        )
+        .unwrap()
+    }
+
+    fn upgrade_minter(&self) {
+        self.env
+            .upgrade_canister(
+                self.minter_id,
+                minter_wasm(),
+                Encode!(&MinterArg::UpgradeArg(Default::default())).unwrap(),
+            )
+            .unwrap();
+    }
+
+    fn check_audit_logs_and_upgrade(self) -> Self {
+        self.check_audit_log();
+        self.env.tick(); //tick before upgrade to finish current timers which are reset afterwards
+        self.upgrade_minter();
+        self
+    }
+}
+
+#[test]
+fn test_eth_get_logs() {
+    let mainnet = CandidRpcClient::from_source(CandidRpcSource::EthMainnet(None));
+}


### PR DESCRIPTION
Configures testing via the `ic_state_machine_tests` crate using similar conventions to the ckETH codebase. 

Resolves #77.

**Next steps:**
- Mock HTTPS outcalls
- Add tests for each Candid-RPC method