### PR TITLE
feat: rename and test `verify_message_signature()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,9 +1785,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "candid",
  "serde",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "askama",
  "async-trait",
@@ -2777,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "k256",
  "lazy_static",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3262,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3270,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "bincode",
  "candid",
@@ -4199,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4341,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "cvt",
  "hex",
@@ -4358,7 +4358,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4436,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "async-trait",
  "candid",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "async-trait",
  "candid",
@@ -4473,7 +4473,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "base32",
  "candid",
@@ -4494,9 +4494,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -5478,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
@@ -5550,7 +5550,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#313e959fad7b1790ccdb8b8595e1a6b2959a611f"
 dependencies = [
  "candid",
  "serde",
@@ -7624,9 +7624,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -106,9 +106,9 @@ type SendRawTransactionResult = variant {
 };
 type SepoliaProvider = variant { BlockPi; PublicNode; Ankr };
 type SignedMessage = record {
-  signature : vec nat8;
+  signature : text;
   message : Message;
-  address : vec nat8;
+  address : text;
 };
 type Source = variant {
   Custom : record { url : text; headers : opt vec HttpHeader };

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -164,6 +164,6 @@ service : {
   set_open_rpc_access : (bool) -> ();
   unregister_provider : (nat64) -> (bool);
   update_provider : (UpdateProviderArgs) -> ();
-  verify_signature : (SignedMessage) -> (bool) query;
+  verify_message_signature : (SignedMessage) -> (bool) query;
   withdraw_accumulated_cycles : (nat64, principal) -> ();
 }

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -4,6 +4,7 @@ import Principal "mo:base/Principal";
 import Evm "mo:evm";
 import Debug "mo:base/Debug";
 import Text "mo:base/Text";
+import Blob "mo:base/Blob";
 
 actor class Main() {
     let mainnet = Evm.Rpc(
@@ -55,18 +56,18 @@ actor class Main() {
             Debug.trap(debug_show result);
         };
 
-        let a1 : Blob = "0xc9b28dca7ea6c5e176a58ba9df53c30ba52c6642";
-        let a2 : Blob = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+        let a1 = "0xc9b28dca7ea6c5e176a58ba9df53c30ba52c6642";
+        let a2 = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
 
-        let m1 = #Data("hello" : Blob);
-        let s1 : Blob = "0x5c0e32248c10f7125b32cae1de9988f2dab686031083302f85b0a82f78e9206516b272fb7641f3e8ab63cf9f3a9b9220b2d6ff2699dc34f0d000d7693ca1ea5e1c";
+        let m1 = #Data(Blob.toArray("hello"));
+        let s1 = "0x5c0e32248c10f7125b32cae1de9988f2dab686031083302f85b0a82f78e9206516b272fb7641f3e8ab63cf9f3a9b9220b2d6ff2699dc34f0d000d7693ca1ea5e1c";
 
-        let m2 = #Data("other" : Blob);
-        let s2 : Blob = "0x27ae1f90fd65c86b07aae1287dba8715db7e429ff9bf700205cb8ac904c6ba071c8fb7c6f8b5e15338521fee95a452c6a688f1c6fec5eeddbfa680a2abf300341b";
+        let m2 = #Data(Blob.toArray("other"));
+        let s2 = "0x27ae1f90fd65c86b07aae1287dba8715db7e429ff9bf700205cb8ac904c6ba071c8fb7c6f8b5e15338521fee95a452c6a688f1c6fec5eeddbfa680a2abf300341b";
 
         // Invalid address
         assert not (
-            await mainnet.verifyMessageSignature({
+            await EvmRpcCanister.verify_message_signature({
                 address = a2;
                 message = m1;
                 signature = s1;
@@ -75,7 +76,7 @@ actor class Main() {
 
         // Invalid message
         assert not (
-            await mainnet.verifyMessageSignature({
+            await EvmRpcCanister.verify_message_signature({
                 address = a1;
                 message = m2;
                 signature = s1;
@@ -84,7 +85,7 @@ actor class Main() {
 
         // Invalid signature
         assert not (
-            await mainnet.verifyMessageSignature({
+            await EvmRpcCanister.verify_message_signature({
                 address = a1;
                 message = m1;
                 signature = s2;
@@ -93,14 +94,14 @@ actor class Main() {
 
         // Valid signature
         assert (
-            await mainnet.verifyMessageSignature({
+            await EvmRpcCanister.verify_message_signature({
                 address = a1;
                 message = m1;
                 signature = s1;
             })
         );
         assert (
-            await mainnet.verifyMessageSignature({
+            await EvmRpcCanister.verify_message_signature({
                 address = a1;
                 message = m2;
                 signature = s2;

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -54,5 +54,57 @@ actor class Main() {
             };
             Debug.trap(debug_show result);
         };
+
+        let a1 : Blob = "0xc9b28dca7ea6c5e176a58ba9df53c30ba52c6642";
+        let a2 : Blob = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+
+        let m1 = #Data("hello" : Blob);
+        let s1 : Blob = "0x5c0e32248c10f7125b32cae1de9988f2dab686031083302f85b0a82f78e9206516b272fb7641f3e8ab63cf9f3a9b9220b2d6ff2699dc34f0d000d7693ca1ea5e1c";
+
+        let m2 = #Data("other" : Blob);
+        let s2 : Blob = "0x27ae1f90fd65c86b07aae1287dba8715db7e429ff9bf700205cb8ac904c6ba071c8fb7c6f8b5e15338521fee95a452c6a688f1c6fec5eeddbfa680a2abf300341b";
+
+        // Invalid address
+        assert not (
+            await mainnet.verifyMessageSignature({
+                address = a2;
+                message = m1;
+                signature = s1;
+            })
+        );
+
+        // Invalid message
+        assert not (
+            await mainnet.verifyMessageSignature({
+                address = a1;
+                message = m2;
+                signature = s1;
+            })
+        );
+
+        // Invalid signature
+        assert not (
+            await mainnet.verifyMessageSignature({
+                address = a1;
+                message = m1;
+                signature = s2;
+            })
+        );
+
+        // Valid signature
+        assert (
+            await mainnet.verifyMessageSignature({
+                address = a1;
+                message = m1;
+                signature = s1;
+            })
+        );
+        assert (
+            await mainnet.verifyMessageSignature({
+                address = a1;
+                message = m2;
+                signature = s2;
+            })
+        );
     };
 };

--- a/lib/motoko/src/lib.mo
+++ b/lib/motoko/src/lib.mo
@@ -50,12 +50,7 @@ module {
         #err : Error;
     };
 
-    public type RpcActor = actor {
-        request : shared (ActorSource, Text, Nat64) -> async {
-            #Ok : Text;
-            #Err : RpcError;
-        };
-    };
+    public type RpcActor = EvmRpc.Self;
 
     public type Provider = {
         #Canister : RpcActor;
@@ -156,11 +151,8 @@ module {
             };
         };
 
-        // public func gasPrice() : async Nat {
-        //     let result = request("eth_gasPrice", #Array([]), 256);
-        //     // TODO: decode
-        //     assert false;
-        //     0;
-        // };
+        public func verifyMessageSignature(signedMessage : EvmRpc.SignedMessage) : async Bool {
+            await actor_.verify_message_signature(signedMessage);
+        };
     };
 };

--- a/lib/motoko/src/lib.mo
+++ b/lib/motoko/src/lib.mo
@@ -28,12 +28,7 @@ module {
         value : Text;
     };
 
-    type ActorSource = {
-        #Custom : { url : Text; headers : ?[HttpHeader] };
-        #Service : { hostname : Text; chain_id : ?Nat64 };
-        #Chain : Nat64;
-        #Provider : Nat64;
-    };
+    type ActorSource = EvmRpc.Source;
 
     public type RpcError = EvmRpc.RpcError;
     public type JsonRpcError = EvmRpc.JsonRpcError;
@@ -50,7 +45,12 @@ module {
         #err : Error;
     };
 
-    public type RpcActor = EvmRpc.Self;
+    public type RpcActor = actor {
+        request : shared (ActorSource, Text, Nat64) -> async {
+            #Ok : Text;
+            #Err : RpcError;
+        };
+    };
 
     public type Provider = {
         #Canister : RpcActor;
@@ -149,10 +149,6 @@ module {
                 };
                 case r r;
             };
-        };
-
-        public func verifyMessageSignature(signedMessage : EvmRpc.SignedMessage) : async Bool {
-            await actor_.verify_message_signature(signedMessage);
         };
     };
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ pub fn verify_message_signature(signed_message: SignedMessage) -> bool {
     do_verify_message_signature(
         &signed_message.address,
         signed_message.message.into(),
-        signed_message.signature,
+        &signed_message.signature,
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,8 +81,8 @@ pub async fn eth_send_raw_transaction(
 
 #[ic_cdk_macros::query]
 #[candid_method(query)]
-pub fn verify_signature(signed_message: SignedMessage) -> bool {
-    do_verify_signature(
+pub fn verify_message_signature(signed_message: SignedMessage) -> bool {
+    do_verify_message_signature(
         &signed_message.address,
         signed_message.message.into(),
         signed_message.signature,

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,20 +1,24 @@
 use ic_eth::core::types::{RecoveryMessage, Signature};
 
+use crate::hex_to_bytes;
+
 pub fn do_verify_message_signature(
-    eth_address: &[u8],
+    eth_address: &str,
     message: RecoveryMessage,
-    signature: Vec<u8>,
+    signature: &str,
 ) -> bool {
-    let eth_address_bytes: [u8; 20] = eth_address
+    let eth_address_bytes: [u8; 20] = hex_to_bytes(eth_address)
+        .unwrap_or_else(|| ic_cdk::trap("invalid hex string for address"))
         .try_into()
         .unwrap_or_else(|_| ic_cdk::trap("expected 20-byte address"));
-    if signature.len() != 65 {
-        ic_cdk::trap("expected 65-byte signature");
-    }
+    let signature_bytes: [u8; 65] = hex_to_bytes(signature)
+        .unwrap_or_else(|| ic_cdk::trap("invalid hex string for signature"))
+        .try_into()
+        .unwrap_or_else(|_| ic_cdk::trap("expected 65-byte signature"));
     Signature {
-        r: signature[..32].into(),
-        s: signature[32..64].into(),
-        v: signature[64].into(),
+        r: signature_bytes[..32].into(),
+        s: signature_bytes[32..64].into(),
+        v: signature_bytes[64].into(),
     }
     .verify(message, eth_address_bytes)
     .is_ok()
@@ -22,21 +26,25 @@ pub fn do_verify_message_signature(
 
 #[test]
 fn test_verify_signature() {
-    let address = &hex::decode("c9b28dca7ea6c5e176a58ba9df53c30ba52c6642").unwrap();
+    let a1 = "0xc9b28dca7ea6c5e176a58ba9df53c30ba52c6642";
+    let a2 = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
 
     let m1 = RecoveryMessage::Data("hello".as_bytes().to_vec());
-    let s1 = hex::decode("5c0e32248c10f7125b32cae1de9988f2dab686031083302f85b0a82f78e9206516b272fb7641f3e8ab63cf9f3a9b9220b2d6ff2699dc34f0d000d7693ca1ea5e1c").unwrap();
+    let s1 = "0x5c0e32248c10f7125b32cae1de9988f2dab686031083302f85b0a82f78e9206516b272fb7641f3e8ab63cf9f3a9b9220b2d6ff2699dc34f0d000d7693ca1ea5e1c";
 
     let m2 = RecoveryMessage::Data("other".as_bytes().to_vec());
-    let s2 = hex::decode("27ae1f90fd65c86b07aae1287dba8715db7e429ff9bf700205cb8ac904c6ba071c8fb7c6f8b5e15338521fee95a452c6a688f1c6fec5eeddbfa680a2abf300341b").unwrap();
+    let s2 = "0x27ae1f90fd65c86b07aae1287dba8715db7e429ff9bf700205cb8ac904c6ba071c8fb7c6f8b5e15338521fee95a452c6a688f1c6fec5eeddbfa680a2abf300341b";
+
+    // Invalid address
+    assert!(!do_verify_message_signature(a2, m1.clone(), s1));
 
     // Invalid message
-    assert!(!do_verify_message_signature(address, m2.clone(), s1.clone()));
+    assert!(!do_verify_message_signature(a1, m2.clone(), s1));
 
     // Invalid signature
-    assert!(!do_verify_message_signature(address, m1.clone(), s2.clone()));
+    assert!(!do_verify_message_signature(a1, m1.clone(), s2));
 
     // Valid signature
-    assert!(do_verify_message_signature(address, m1, s1));
-    assert!(do_verify_message_signature(address, m2, s2));
+    assert!(do_verify_message_signature(a1, m1, s1));
+    assert!(do_verify_message_signature(a1, m2, s2));
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,6 +1,6 @@
 use ic_eth::core::types::{RecoveryMessage, Signature};
 
-pub fn do_verify_signature(
+pub fn do_verify_message_signature(
     eth_address: &[u8],
     message: RecoveryMessage,
     signature: Vec<u8>,
@@ -31,12 +31,12 @@ fn test_verify_signature() {
     let s2 = hex::decode("27ae1f90fd65c86b07aae1287dba8715db7e429ff9bf700205cb8ac904c6ba071c8fb7c6f8b5e15338521fee95a452c6a688f1c6fec5eeddbfa680a2abf300341b").unwrap();
 
     // Invalid message
-    assert!(!do_verify_signature(address, m2.clone(), s1.clone()));
+    assert!(!do_verify_message_signature(address, m2.clone(), s1.clone()));
 
     // Invalid signature
-    assert!(!do_verify_signature(address, m1.clone(), s2.clone()));
+    assert!(!do_verify_message_signature(address, m1.clone(), s2.clone()));
 
     // Valid signature
-    assert!(do_verify_signature(address, m1, s1));
-    assert!(do_verify_signature(address, m2, s2));
+    assert!(do_verify_message_signature(address, m1, s1));
+    assert!(do_verify_message_signature(address, m2, s2));
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -306,10 +306,9 @@ impl From<Message> for RecoveryMessage {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct SignedMessage {
-    // TODO: Candid `blob` in place of `vec nat8`
-    pub address: Vec<u8>,
+    pub address: String,
     pub message: Message,
-    pub signature: Vec<u8>,
+    pub signature: String,
 }
 
 pub type RpcResult<T> = Result<T, RpcError>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,10 @@
-use candid::Principal;
 use serde_json::Value;
 
-pub fn to_principal(principal: &str) -> Principal {
-    match Principal::from_text(principal) {
-        Ok(p) => p,
-        Err(e) => ic_cdk::trap(&format!("failed to convert Principal {principal} {e:?}",)),
+pub fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
+    if !hex.starts_with("0x") {
+        return None;
     }
+    hex::decode(&hex[2..]).ok()
 }
 
 pub fn canonicalize_json(text: &[u8]) -> Option<Vec<u8>> {
@@ -14,9 +13,17 @@ pub fn canonicalize_json(text: &[u8]) -> Option<Vec<u8>> {
 }
 
 #[test]
+fn test_hex_to_bytes() {
+    assert_eq!(hex_to_bytes("aa"), None);
+    assert_eq!(hex_to_bytes("0x"), Some(vec![]));
+    assert_eq!(hex_to_bytes("0xAA"), Some(vec![0xAA]));
+    assert_eq!(hex_to_bytes("0xaa"), Some(vec![0xAA]));
+}
+
+#[test]
 fn test_canonicalize_json() {
     assert_eq!(
         canonicalize_json(r#"{"A":1,"B":2}"#.as_bytes()).unwrap(),
         canonicalize_json(r#"{"B":2,"A":1}"#.as_bytes()).unwrap()
-    )
+    );
 }


### PR DESCRIPTION
* Renames `verify_signature()` to `verify_message_signature()`
* Includes Motoko E2E tests to confirm that this function can be called with reasonable convenience.

See [this Google Docs comment thread](https://docs.google.com/document/d/1cedAnlPieO61EXbLL28ar9pJviT_e9daHJrweKZY9Uw/edit?pli=1&disco=AAABBGXin10) for context.
