### PR TITLE
chore: update providers based on new ckETH repo changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7719,8 +7719,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wasm-bindgen"
 version = "0.2.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+source = "git+https://github.com/rvanasa/wasm-bindgen?rev=62965b0749ca68237e2ab3da487c141a5b3dbd2d#62965b0749ca68237e2ab3da487c141a5b3dbd2d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -7728,9 +7727,8 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+version = "0.2.88"
+source = "git+https://github.com/rvanasa/wasm-bindgen?rev=62965b0749ca68237e2ab3da487c141a5b3dbd2d#62965b0749ca68237e2ab3da487c141a5b3dbd2d"
 dependencies = [
  "bumpalo",
  "log",
@@ -7755,9 +7753,8 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+version = "0.2.88"
+source = "git+https://github.com/rvanasa/wasm-bindgen?rev=62965b0749ca68237e2ab3da487c141a5b3dbd2d#62965b0749ca68237e2ab3da487c141a5b3dbd2d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7765,9 +7762,8 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+version = "0.2.88"
+source = "git+https://github.com/rvanasa/wasm-bindgen?rev=62965b0749ca68237e2ab3da487c141a5b3dbd2d#62965b0749ca68237e2ab3da487c141a5b3dbd2d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7778,9 +7774,8 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+version = "0.2.88"
+source = "git+https://github.com/rvanasa/wasm-bindgen?rev=62965b0749ca68237e2ab3da487c141a5b3dbd2d#62965b0749ca68237e2ab3da487c141a5b3dbd2d"
 
 [[package]]
 name = "wasm-encoder"
@@ -8365,8 +8360,3 @@ dependencies = [
  "quote",
  "syn 2.0.39",
 ]
-
-[[patch.unused]]
-name = "wasm-bindgen"
-version = "0.2.88"
-source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f81ab4bf345cda2bc39#d50634da14c5bd031edd4f81ab4bf345cda2bc39"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli 0.28.0",
+ "gimli 0.28.1",
 ]
 
 [[package]]
@@ -120,24 +120,33 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb98f10f371286b177db5eeb9a6e5396609555686a35e1d4f7b9a9c6d8af0139"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
 dependencies = [
  "askama_derive",
  "askama_escape",
- "askama_shared",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.11.2"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
+checksum = "9a0fc7dcf8bd4ead96b1d36b41df47c14beedf7b0301fc543d8f2384e66a2ec0"
 dependencies = [
- "askama_shared",
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
  "proc-macro2",
- "syn 1.0.109",
+ "quote",
+ "serde",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -147,23 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
-name = "askama_shared"
-version = "0.12.2"
+name = "askama_parser"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf722b94118a07fcbc6640190f247334027685d4e218b794dbfe17c32bf38ed0"
+checksum = "c268a96e01a4c47c8c5c2472aaa570707e006a875ea63e819f75474ceedaf7b4"
 dependencies = [
- "askama_escape",
- "humansize",
- "mime",
- "mime_guess",
  "nom",
- "num-traits",
- "percent-encoding",
- "proc-macro2",
- "quote",
- "serde",
- "syn 1.0.109",
- "toml",
 ]
 
 [[package]]
@@ -379,6 +377,15 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "beef"
@@ -761,7 +768,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -912,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -922,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpp_demangle"
@@ -1045,7 +1052,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "smallvec",
  "wasmparser 0.107.0",
@@ -1244,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
 ]
@@ -1303,7 +1310,7 @@ dependencies = [
  "dfn_core",
  "ic-base-types 0.8.0",
  "on_wire",
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -1524,12 +1531,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1977,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -2066,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hashers"
@@ -2155,7 +2162,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2194,9 +2201,12 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humansize"
-version = "1.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -2301,7 +2311,7 @@ name = "ic-adapter-metrics-service"
 version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 dependencies = [
- "prost",
+ "prost 0.11.9",
  "prost-build",
  "tonic",
  "tonic-build",
@@ -2340,7 +2350,7 @@ dependencies = [
  "ic-protobuf 0.8.0",
  "ic-stable-structures",
  "phantom_newtype 0.8.0",
- "prost",
+ "prost 0.11.9",
  "serde",
  "strum 0.23.0",
  "strum_macros 0.23.1",
@@ -2349,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2361,7 +2371,7 @@ dependencies = [
  "ic-protobuf 0.9.0",
  "ic-stable-structures",
  "phantom_newtype 0.9.0",
- "prost",
+ "prost 0.12.3",
  "serde",
  "strum 0.24.1",
  "strum_macros 0.24.3",
@@ -2392,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2510,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "candid",
  "serde",
@@ -2532,7 +2542,7 @@ dependencies = [
  "ic-registry-subnet-type",
  "ic-replicated-state",
  "ic-types",
- "itertools",
+ "itertools 0.10.5",
  "leb128",
  "phantom_newtype 0.8.0",
  "scoped_threadpool",
@@ -2548,7 +2558,7 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 dependencies = [
  "ic-crypto-tree-hash",
- "itertools",
+ "itertools 0.10.5",
  "leb128",
  "scoped_threadpool",
  "thiserror",
@@ -2642,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "askama",
  "async-trait",
@@ -2777,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2964,7 +2974,7 @@ dependencies = [
  "hex",
  "ic-crypto-getrandom-for-wasm",
  "ic_bls12_381",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "pairing",
  "paste",
@@ -3010,7 +3020,7 @@ dependencies = [
  "ic-types",
  "ic-utils 0.8.0",
  "parking_lot 0.12.1",
- "prost",
+ "prost 0.11.9",
  "rand",
  "rand_chacha",
  "rcgen 0.10.0",
@@ -3096,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3262,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3270,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3484,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3587,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3645,7 +3655,7 @@ dependencies = [
  "ic-types",
  "ic-utils 0.8.0",
  "ic-wasm-types",
- "prost",
+ "prost 0.11.9",
  "rand",
  "serde",
  "serde_bytes",
@@ -3667,7 +3677,7 @@ version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 dependencies = [
  "ic-types",
- "prost",
+ "prost 0.11.9",
  "serde",
 ]
 
@@ -3831,7 +3841,7 @@ dependencies = [
  "maplit",
  "mockall",
  "priority-queue",
- "prost",
+ "prost 0.11.9",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -3868,7 +3878,7 @@ dependencies = [
  "candid",
  "erased-serde",
  "maplit",
- "prost",
+ "prost 0.11.9",
  "serde",
  "serde_json",
  "slog",
@@ -3877,13 +3887,13 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "bincode",
  "candid",
  "erased-serde",
  "maplit",
- "prost",
+ "prost 0.12.3",
  "serde",
  "serde_json",
  "slog",
@@ -3922,7 +3932,7 @@ name = "ic-registry-common-proto"
 version = "0.8.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 dependencies = [
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -4003,7 +4013,7 @@ dependencies = [
  "candid",
  "ic-base-types 0.8.0",
  "ic-protobuf 0.8.0",
- "prost",
+ "prost 0.11.9",
  "serde",
 ]
 
@@ -4071,7 +4081,7 @@ dependencies = [
  "ic-wasm-types",
  "libc",
  "prometheus",
- "prost",
+ "prost 0.11.9",
  "scoped_threadpool",
  "serde",
  "serde_bytes",
@@ -4170,7 +4180,7 @@ dependencies = [
  "nix 0.23.2",
  "parking_lot 0.12.1",
  "prometheus",
- "prost",
+ "prost 0.11.9",
  "rand",
  "rand_chacha",
  "scoped_threadpool",
@@ -4199,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4309,7 +4319,7 @@ dependencies = [
  "maplit",
  "once_cell",
  "phantom_newtype 0.8.0",
- "prost",
+ "prost 0.11.9",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -4331,7 +4341,7 @@ dependencies = [
  "ic-sys 0.8.0",
  "libc",
  "nix 0.23.2",
- "prost",
+ "prost 0.11.9",
  "rand",
  "scoped_threadpool",
  "serde",
@@ -4341,14 +4351,14 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "cvt",
  "hex",
  "ic-sys 0.9.0",
  "libc",
  "nix 0.24.3",
- "prost",
+ "prost 0.12.3",
  "rand",
  "scoped_threadpool",
  "serde",
@@ -4358,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4424,8 +4434,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "on_wire",
- "prost",
- "prost-derive",
+ "prost 0.11.9",
+ "prost-derive 0.11.9",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -4436,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "async-trait",
  "candid",
@@ -4447,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "async-trait",
  "candid",
@@ -4473,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "base32",
  "candid",
@@ -4558,7 +4568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -4578,7 +4588,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.3",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4594,8 +4604,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.25",
- "windows-sys",
+ "rustix 0.38.26",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4608,6 +4618,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,9 +4634,9 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4681,7 +4700,7 @@ dependencies = [
  "diff",
  "ena",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -4768,9 +4787,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "lock_api"
@@ -4870,7 +4889,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.25",
+ "rustix 0.38.26",
 ]
 
 [[package]]
@@ -4976,7 +4995,7 @@ checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5370,9 +5389,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.5"
+version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
+checksum = "881331e34fa842a2fb61cc2db9643a8fedc615e47cfcc52597d1af0db9a7e8fe"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
@@ -5384,11 +5403,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.5"
+version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
+checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5439,7 +5458,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.4.1",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5550,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#fc43f0f42bb1606713cd89cf4917b1554d129f1d"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#762850168e8fa6168ce6d4255de86e39b24a4f36"
 dependencies = [
  "candid",
  "serde",
@@ -5667,7 +5686,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -5804,9 +5823,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5865,7 +5884,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -5876,13 +5905,13 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.11.9",
  "prost-types",
  "regex",
  "syn 1.0.109",
@@ -5897,10 +5926,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5909,7 +5951,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -6209,16 +6251,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
  "getrandom 0.2.11",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6279,9 +6321,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.4"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3211b01eea83d80687da9eef70e39d65144a3894866a5153a2723e425a157f"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
  "const-oid",
  "digest 0.10.7",
@@ -6361,20 +6403,20 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.11",
- "windows-sys",
+ "linux-raw-sys 0.4.12",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6384,7 +6426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
- "ring 0.17.5",
+ "ring 0.17.6",
  "rustls-webpki",
  "sct",
 ]
@@ -6395,7 +6437,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.6",
  "untrusted 0.9.0",
 ]
 
@@ -6453,7 +6495,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.5",
+ "ring 0.17.6",
  "untrusted 0.9.0",
 ]
 
@@ -6766,9 +6808,9 @@ dependencies = [
 
 [[package]]
 name = "slotmap"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
 dependencies = [
  "version_check",
 ]
@@ -6796,7 +6838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6813,9 +6855,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -7092,8 +7134,8 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.4.1",
- "rustix 0.38.25",
- "windows-sys",
+ "rustix 0.38.26",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7244,7 +7286,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7333,15 +7375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7388,7 +7421,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.11.9",
  "tokio",
  "tokio-stream",
  "tower",
@@ -7685,8 +7718,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
-source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f81ab4bf345cda2bc39#d50634da14c5bd031edd4f81ab4bf345cda2bc39"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -7694,8 +7728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
-source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f81ab4bf345cda2bc39#d50634da14c5bd031edd4f81ab4bf345cda2bc39"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -7708,9 +7743,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7720,8 +7755,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
-source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f81ab4bf345cda2bc39#d50634da14c5bd031edd4f81ab4bf345cda2bc39"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7729,8 +7765,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
-source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f81ab4bf345cda2bc39#d50634da14c5bd031edd4f81ab4bf345cda2bc39"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7741,8 +7778,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
-source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f81ab4bf345cda2bc39#d50634da14c5bd031edd4f81ab4bf345cda2bc39"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-encoder"
@@ -7755,9 +7793,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b09bc5df933a3dabbdb72ae4b6b71be8ae07f58774d5aa41bd20adcd41a235a"
+checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
 dependencies = [
  "leb128",
 ]
@@ -7809,7 +7847,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit",
  "wasmtime-runtime",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7900,7 +7938,7 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7920,7 +7958,7 @@ checksum = "517750d84b6ebdb2c32226cee412c7e6aa48e4cebbb259d9a227b4317426adc6"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7945,7 +7983,7 @@ dependencies = [
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7962,30 +8000,30 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "69.0.0"
+version = "69.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa51b5ad1391943d1bfad537e50f28fe938199ee76b115be6bae83802cd5185"
+checksum = "c1ee37317321afde358e4d7593745942c48d6d17e0e6e943704de9bbee121e7a"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.38.0",
+ "wasm-encoder 0.38.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a4c2488d058326466e086a43f5d4ea448241a8d0975e3eb0642c0828be1eb3"
+checksum = "aeb338ee8dee4d4cd05e6426683f21c5087dc7cfc8903e839ccf48d43332da3c"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8000,7 +8038,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.25",
+ "rustix 0.38.26",
 ]
 
 [[package]]
@@ -8040,7 +8078,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -8049,7 +8087,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -8058,13 +8105,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -8074,10 +8136,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8086,10 +8160,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8098,10 +8184,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8110,10 +8208,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "winnow"
-version = "0.5.19"
+name = "windows_x86_64_msvc"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.5.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38cf28f534400ca4195b18033e02c5dd7c36b1138a56f2cfebca48112b528f63"
 dependencies = [
  "memchr",
 ]
@@ -8125,7 +8229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8224,18 +8328,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8261,3 +8365,8 @@ dependencies = [
  "quote",
  "syn 2.0.39",
 ]
+
+[[patch.unused]]
+name = "wasm-bindgen"
+version = "0.2.88"
+source = "git+https://github.com/rvanasa/wasm-bindgen?rev=d50634da14c5bd031edd4f81ab4bf345cda2bc39#d50634da14c5bd031edd4f81ab4bf345cda2bc39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [profile.release]
 debug = false
 lto = true
-opt-level = 's'
+opt-level = 'z'
 
 # Required by `ic-test-utilities-load-wasm`
 [profile.canister-release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [profile.release]
 debug = false
 lto = true
-opt-level = 'z'
+opt-level = 's'
 
 # Required by `ic-test-utilities-load-wasm`
 [profile.canister-release]
@@ -46,7 +46,7 @@ ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", rev = "re
 assert_matches = "1.5"
 
 [workspace.dependencies]
-candid = { version = "0.9", features = ["parser"] }
+candid = { version = "0.9" }
 ic-canister-log = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
@@ -59,7 +59,7 @@ ic-cdk-bindgen = "0.1"
 ic-eth = { path = "lib/rust" }
 
 [patch.crates-io]
-wasm-bindgen = { git = "https://github.com/rvanasa/wasm-bindgen", rev = "d50634da14c5bd031edd4f81ab4bf345cda2bc39" }
+wasm-bindgen = { git = "https://github.com/rvanasa/wasm-bindgen", rev = "62965b0749ca68237e2ab3da487c141a5b3dbd2d" }
 
 [workspace]
 members = ["lib/rust", "e2e/rust"]

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -14,6 +14,7 @@ type CandidRpcSource = variant {
   EthMainnet : opt EthMainnetService;
 };
 type EthMainnetService = variant { BlockPi; Cloudflare; PublicNode; Ankr };
+type EthSepoliaService = variant { BlockPi; PublicNode; Ankr };
 type FeeHistory = record {
   reward : vec vec nat;
   base_fee_per_gas : vec nat;
@@ -104,7 +105,6 @@ type SendRawTransactionResult = variant {
   NonceTooHigh;
   InsufficientFunds;
 };
-type EthSepoliaService = variant { BlockPi; PublicNode; Ankr };
 type SignedMessage = record {
   signature : vec nat8;
   message : Message;

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -10,10 +10,10 @@ type BlockTag = variant {
   Pending;
 };
 type CandidRpcSource = variant {
-  EthSepolia : opt SepoliaProvider;
-  EthMainnet : opt EthereumProvider;
+  EthSepolia : opt EthSepoliaService;
+  EthMainnet : opt EthMainnetService;
 };
-type EthereumProvider = variant { BlockPi; Cloudflare; Ankr };
+type EthMainnetService = variant { BlockPi; Cloudflare; PublicNode; Ankr };
 type FeeHistory = record {
   reward : vec vec nat;
   base_fee_per_gas : vec nat;
@@ -104,7 +104,7 @@ type SendRawTransactionResult = variant {
   NonceTooHigh;
   InsufficientFunds;
 };
-type SepoliaProvider = variant { BlockPi; PublicNode; Ankr };
+type EthSepoliaService = variant { BlockPi; PublicNode; Ankr };
 type SignedMessage = record {
   signature : vec nat8;
   message : Message;

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -36,18 +36,18 @@ impl RpcTransport for CanisterTransport {
             EthMainnet(provider) => (
                 ETH_MAINNET_CHAIN_ID,
                 match provider {
-                    EthMainnetService::Ankr => "rpc.ankr.com",
-                    EthMainnetService::BlockPi => "ethereum.blockpi.network",
-                    EthMainnetService::PublicNode => "ethereum.publicnode.com",
-                    EthMainnetService::Cloudflare => "cloudflare-eth.com",
+                    EthMainnetService::Ankr => ANKR_HOSTNAME,
+                    EthMainnetService::BlockPi => BLOCKPI_ETH_MAINNET_HOSTNAME,
+                    EthMainnetService::PublicNode => PUBLICNODE_ETH_MAINNET_HOSTNAME,
+                    EthMainnetService::Cloudflare => CLOUDFLARE_ETH_HOSTNAME,
                 },
             ),
             EthSepolia(provider) => (
                 ETH_SEPOLIA_CHAIN_ID,
                 match provider {
-                    EthSepoliaService::Ankr => "rpc.ankr.com",
-                    EthSepoliaService::BlockPi => "ethereum-sepolia.blockpi.network",
-                    EthSepoliaService::PublicNode => "ethereum-sepolia.publicnode.com",
+                    EthSepoliaService::Ankr => ANKR_HOSTNAME,
+                    EthSepoliaService::BlockPi => BLOCKPI_ETH_SEPOLIA_HOSTNAME,
+                    EthSepoliaService::PublicNode => PUBLICNODE_ETH_SEPOLIA_HOSTNAME,
                 },
             ),
         };

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-use cketh_common::eth_rpc_client::providers::{EthereumProvider, SepoliaProvider};
+use cketh_common::eth_rpc_client::providers::{EthMainnetService, EthSepoliaService};
 
 pub const INGRESS_OVERHEAD_BYTES: u128 = 100;
 pub const INGRESS_MESSAGE_RECEIVED_COST: u128 = 1_200_000;
@@ -16,8 +16,8 @@ pub const DEFAULT_NODES_IN_SUBNET: u32 = 13;
 pub const DEFAULT_OPEN_RPC_ACCESS: bool = true;
 
 // Providers used by default (when passing `null` with `CandidRpcSource`)
-pub const DEFAULT_ETHEREUM_PROVIDER: EthereumProvider = EthereumProvider::Ankr;
-pub const DEFAULT_SEPOLIA_PROVIDER: SepoliaProvider = SepoliaProvider::PublicNode;
+pub const DEFAULT_ETHEREUM_PROVIDER: EthMainnetService = EthMainnetService::Ankr;
+pub const DEFAULT_SEPOLIA_PROVIDER: EthSepoliaService = EthSepoliaService::PublicNode;
 
 pub const CONTENT_TYPE_HEADER: &str = "Content-Type";
 pub const CONTENT_TYPE_VALUE: &str = "application/json";

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -19,6 +19,14 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
             cycles_per_message_byte: 0,
         },
         RegisterProviderArgs {
+            chain_id: ETH_SEPOLIA_CHAIN_ID,
+            hostname: "ethereum.publicnode.com".to_string(),
+            credential_path: "".to_string(),
+            credential_headers: None,
+            cycles_per_call: 0,
+            cycles_per_message_byte: 0,
+        },
+        RegisterProviderArgs {
             chain_id: ETH_MAINNET_CHAIN_ID,
             hostname: "ethereum.blockpi.network".to_string(),
             credential_path: "/v1/rpc/public".to_string(),

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1,10 +1,18 @@
 use crate::*;
 
+pub const CLOUDFLARE_ETH_HOSTNAME: &str = "cloudflare-eth.com";
+pub const ANKR_HOSTNAME: &str = "rpc.ankr.com";
+pub const PUBLICNODE_ETH_MAINNET_HOSTNAME: &str = "ethereum.publicnode.com";
+pub const BLOCKPI_ETH_MAINNET_HOSTNAME: &str = "ethereum.blockpi.network";
+pub const ETH_SEPOLIA_HOSTNAME: &str = "rpc.sepolia.org";
+pub const BLOCKPI_ETH_SEPOLIA_HOSTNAME: &str = "ethereum-sepolia.blockpi.network";
+pub const PUBLICNODE_ETH_SEPOLIA_HOSTNAME: &str = "ethereum-sepolia.publicnode.com";
+
 pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
     vec![
         RegisterProviderArgs {
             chain_id: ETH_MAINNET_CHAIN_ID,
-            hostname: "cloudflare-eth.com".to_string(),
+            hostname: CLOUDFLARE_ETH_HOSTNAME.to_string(),
             credential_path: "/v1/mainnet".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -12,7 +20,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
         },
         RegisterProviderArgs {
             chain_id: ETH_MAINNET_CHAIN_ID,
-            hostname: "rpc.ankr.com".to_string(),
+            hostname: ANKR_HOSTNAME.to_string(),
             credential_path: "/eth".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -20,7 +28,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
         },
         RegisterProviderArgs {
             chain_id: ETH_SEPOLIA_CHAIN_ID,
-            hostname: "ethereum.publicnode.com".to_string(),
+            hostname: PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string(),
             credential_path: "".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -28,7 +36,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
         },
         RegisterProviderArgs {
             chain_id: ETH_MAINNET_CHAIN_ID,
-            hostname: "ethereum.blockpi.network".to_string(),
+            hostname: BLOCKPI_ETH_MAINNET_HOSTNAME.to_string(),
             credential_path: "/v1/rpc/public".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -36,7 +44,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
         },
         RegisterProviderArgs {
             chain_id: ETH_SEPOLIA_CHAIN_ID,
-            hostname: "rpc.sepolia.org".to_string(),
+            hostname: ETH_SEPOLIA_HOSTNAME.to_string(),
             credential_path: "".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -44,7 +52,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
         },
         RegisterProviderArgs {
             chain_id: ETH_SEPOLIA_CHAIN_ID,
-            hostname: "rpc.ankr.com".to_string(),
+            hostname: ANKR_HOSTNAME.to_string(),
             credential_path: "/eth_sepolia".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -52,7 +60,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
         },
         RegisterProviderArgs {
             chain_id: ETH_SEPOLIA_CHAIN_ID,
-            hostname: "ethereum-sepolia.blockpi.network".to_string(),
+            hostname: BLOCKPI_ETH_SEPOLIA_HOSTNAME.to_string(),
             credential_path: "/v1/rpc/public".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -60,7 +68,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
         },
         RegisterProviderArgs {
             chain_id: ETH_SEPOLIA_CHAIN_ID,
-            hostname: "ethereum-sepolia.publicnode.com".to_string(),
+            hostname: PUBLICNODE_ETH_SEPOLIA_HOSTNAME.to_string(),
             credential_path: "".to_string(),
             credential_headers: None,
             cycles_per_call: 0,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use candid::{CandidType, Decode, Deserialize, Encode, Principal};
 use cketh_common::eth_rpc::{ProviderError, RpcError};
-use cketh_common::eth_rpc_client::providers::{EthereumProvider, RpcApi, SepoliaProvider};
+use cketh_common::eth_rpc_client::providers::{EthMainnetService, EthSepoliaService, RpcApi};
 
 use ic_cdk::api::management_canister::http_request::HttpHeader;
 use ic_eth::core::types::RecoveryMessage;
@@ -316,8 +316,8 @@ pub type RpcResult<T> = Result<T, RpcError>;
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum CandidRpcSource {
-    EthMainnet(Option<EthereumProvider>),
-    EthSepolia(Option<SepoliaProvider>),
+    EthMainnet(Option<EthMainnetService>),
+    EthSepolia(Option<EthSepoliaService>),
 }
 
 pub mod candid_types {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -331,7 +331,7 @@ fn should_register_provider() {
     let a_id = setup
         .register_provider(RegisterProviderArgs {
             chain_id: 1,
-            hostname: "example.com".to_string(),
+            hostname: ANKR_HOSTNAME.to_string(),
             credential_path: "".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -362,7 +362,7 @@ fn should_register_provider() {
                 provider_id: first_new_id,
                 owner: setup.caller.0,
                 chain_id: 1,
-                hostname: "example.com".to_string(),
+                hostname: ANKR_HOSTNAME.to_string(),
                 cycles_per_call: 0,
                 cycles_per_message_byte: 0,
                 primary: false,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -331,7 +331,7 @@ fn should_register_provider() {
     let a_id = setup
         .register_provider(RegisterProviderArgs {
             chain_id: 1,
-            hostname: "cloudflare-eth.com".to_string(),
+            hostname: "example.com".to_string(),
             credential_path: "".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -341,9 +341,12 @@ fn should_register_provider() {
     let b_id = setup
         .register_provider(RegisterProviderArgs {
             chain_id: 5,
-            hostname: "ethereum.publicnode.com".to_string(),
-            credential_path: "".to_string(),
-            credential_headers: None,
+            hostname: CLOUDFLARE_ETH_HOSTNAME.to_string(),
+            credential_path: "/test-path".to_string(),
+            credential_headers: Some(vec![HttpHeader {
+                name: "Test-Authorization".to_string(),
+                value: "---".to_string(),
+            }]),
             cycles_per_call: 0,
             cycles_per_message_byte: 0,
         })
@@ -359,7 +362,7 @@ fn should_register_provider() {
                 provider_id: first_new_id,
                 owner: setup.caller.0,
                 chain_id: 1,
-                hostname: "cloudflare-eth.com".to_string(),
+                hostname: "example.com".to_string(),
                 cycles_per_call: 0,
                 cycles_per_message_byte: 0,
                 primary: false,
@@ -368,7 +371,7 @@ fn should_register_provider() {
                 provider_id: first_new_id + 1,
                 owner: setup.caller.0,
                 chain_id: 5,
-                hostname: "ethereum.publicnode.com".to_string(),
+                hostname: CLOUDFLARE_ETH_HOSTNAME.to_string(),
                 cycles_per_call: 0,
                 cycles_per_message_byte: 0,
                 primary: false,


### PR DESCRIPTION
* Adds a new `EthMainnetService::PublicNode` variant and default provider
* Refactors to account for changes to the ckETH codebase over the past few weeks
