### PR TITLE
Add fiduciary subnet test canister

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Beyond the Ethereum blockchain, this canister also supports Polygon, Avalanche, 
 
 ## Canisters
 
-* Staging (only use for testing on the mainnet): [a6d44-nyaaa-aaaap-abp7q-cai](https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.ic0.app/?id=a6d44-nyaaa-aaaap-abp7q-cai)
+* Test canisters (no API keys):
+  * Standard subnet (13 nodes): [`a6d44-nyaaa-aaaap-abp7q-cai`](https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.ic0.app/?id=a6d44-nyaaa-aaaap-abp7q-cai)
+  * Fiduciary subnet (28 nodes): [`xhcuo-6yaaa-aaaar-qacqq-cai`](https://xhcuo-6yaaa-aaaar-qacqq-cai.raw.ic0.app/?id=a6d44-nyaaa-aaaap-abp7q-cai)
 
 ## Quick Start
 

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,5 +1,8 @@
 {
   "evm_rpc": {
     "ic": "a6d44-nyaaa-aaaap-abp7q-cai"
+  },
+  "evm_rpc_fiduciary": {
+    "ic": "xhcuo-6yaaa-aaaar-qacqq-cai"
   }
 }

--- a/dfx.json
+++ b/dfx.json
@@ -9,6 +9,15 @@
         "output": "lib/motoko/src/declarations"
       }
     },
+    "evm_rpc_fiduciary": {
+      "candid": "candid/evm_rpc_fiduciary.did",
+      "type": "rust",
+      "package": "evm_rpc",
+      "declarations": {
+        "bindings": ["did", "mo"],
+        "output": "lib/motoko/src/declarations"
+      }
+    },
     "e2e_rust": {
       "dependencies": ["evm_rpc"],
       "candid": "e2e/rust/e2e_rust.did",

--- a/dfx.json
+++ b/dfx.json
@@ -10,13 +10,9 @@
       }
     },
     "evm_rpc_fiduciary": {
-      "candid": "candid/evm_rpc_fiduciary.did",
+      "candid": "candid/evm_rpc.did",
       "type": "rust",
-      "package": "evm_rpc",
-      "declarations": {
-        "bindings": ["did", "mo"],
-        "output": "lib/motoko/src/declarations"
-      }
+      "package": "evm_rpc"
     },
     "e2e_rust": {
       "dependencies": ["evm_rpc"],

--- a/scripts/examples
+++ b/scripts/examples
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Run a variety of example RPC calls.
 
+CANISTER_NAME=evm_rpc
 CYCLES=100000000000
 WALLET=$(dfx identity get-wallet)
 JSON_SOURCE=Chain=1
@@ -9,13 +10,11 @@ CANDID_SOURCE=EthMainnet
 FLAGS="--with-cycles=$CYCLES --wallet=$WALLET"
 
 
-dfx canister call evm_rpc request "(variant {$JSON_SOURCE}, "'"{ \"jsonrpc\": \"2.0\", \"method\": \"eth_gasPrice\", \"params\": [], \"id\": 1 }"'", 1000)" $FLAGS || exit 1
+dfx canister call $CANISTER_NAME request "(variant {$JSON_SOURCE}, "'"{ \"jsonrpc\": \"2.0\", \"method\": \"eth_gasPrice\", \"params\": [], \"id\": 1 }"'", 1000)" $FLAGS || exit 1
 
-dfx canister call evm_rpc eth_get_logs "(variant {$CANDID_SOURCE}, record {addresses = vec {\"0xdAC17F958D2ee523a2206206994597C13D831ec7\"}})" $FLAGS || exit 1
-dfx canister call evm_rpc eth_get_block_by_number "(variant {$CANDID_SOURCE}, variant {Tag=variant {Latest}})" $FLAGS || exit 1
-dfx canister call evm_rpc eth_get_transaction_receipt "(variant {$CANDID_SOURCE}, \"0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f\")" $FLAGS || exit 1
-dfx canister call evm_rpc eth_get_transaction_count "(variant {$CANDID_SOURCE}, record {address = \"0xdAC17F958D2ee523a2206206994597C13D831ec7\"; block = variant {Tag = variant {Latest}}})" $FLAGS || exit 1
-dfx canister call evm_rpc eth_fee_history "(variant {$CANDID_SOURCE}, record {block_count = 3; newest_block = variant {Tag = variant {Latest}}})" $FLAGS || exit 1
-dfx canister call evm_rpc eth_send_raw_transaction "(variant {$CANDID_SOURCE}, \"0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83\")" $FLAGS || exit 1
-
-# dfx canister call evm_rpc verify_signature ... || exit 1
+dfx canister call $CANISTER_NAME eth_get_logs "(variant {$CANDID_SOURCE}, record {addresses = vec {\"0xdAC17F958D2ee523a2206206994597C13D831ec7\"}})" $FLAGS || exit 1
+dfx canister call $CANISTER_NAME eth_get_block_by_number "(variant {$CANDID_SOURCE}, variant {Tag=variant {Latest}})" $FLAGS || exit 1
+dfx canister call $CANISTER_NAME eth_get_transaction_receipt "(variant {$CANDID_SOURCE}, \"0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f\")" $FLAGS || exit 1
+dfx canister call $CANISTER_NAME eth_get_transaction_count "(variant {$CANDID_SOURCE}, record {address = \"0xdAC17F958D2ee523a2206206994597C13D831ec7\"; block = variant {Tag = variant {Latest}}})" $FLAGS || exit 1
+dfx canister call $CANISTER_NAME eth_fee_history "(variant {$CANDID_SOURCE}, record {block_count = 3; newest_block = variant {Tag = variant {Latest}}})" $FLAGS || exit 1
+dfx canister call $CANISTER_NAME eth_send_raw_transaction "(variant {$CANDID_SOURCE}, \"0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83\")" $FLAGS || exit 1


### PR DESCRIPTION
This PR sets up and documents a new staging canister deployed on the fiduciary subnet ([Candid UI](https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=xhcuo-6yaaa-aaaar-qacqq-cai)).
