### PR TITLE
feat!: include all JSON properties in Candid-RPC responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "candid",
  "serde",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "askama",
  "async-trait",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "k256",
  "lazy_static",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3596,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "bincode",
  "candid",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "cvt",
  "hex",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "async-trait",
  "candid",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "async-trait",
  "candid",
@@ -4482,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "base32",
  "candid",
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b96861cb2718dfd8285f8761144b9e9d2c47b384"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "candid",
  "serde",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "askama",
  "async-trait",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "k256",
  "lazy_static",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3596,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "bincode",
  "candid",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "cvt",
  "hex",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "async-trait",
  "candid",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "async-trait",
  "candid",
@@ -4482,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "base32",
  "candid",
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#076f630bccdb4220f36d4300e9596fa70731cbd0"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2519,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "candid",
  "serde",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "askama",
  "async-trait",
@@ -2786,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "k256",
  "lazy_static",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3596,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "bincode",
  "candid",
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "cvt",
  "hex",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "async-trait",
  "candid",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "async-trait",
  "candid",
@@ -4482,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "base32",
  "candid",
@@ -5568,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#7664f0078c041c0f8f9889b6138024b056e1d2c3"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -239,7 +239,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -515,7 +515,7 @@ dependencies = [
  "proc-macro-crate 2.0.1",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
  "syn_derive",
 ]
 
@@ -710,7 +710,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+checksum = "14c3242926edf34aec4ac3a77108ad4854bffaa2e4ddc1824124ce59231302d5"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "fca89a0e215bab21874660c67903c5f143333cab1da83d041c7ded6053774751"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -1091,22 +1091,21 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset 0.9.0",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+checksum = "c06d96137f14f244c37f989d9fff8f95e6c18b918e71f36638f8c49112e4c78f"
 dependencies = [
  "cfg-if",
 ]
@@ -1375,7 +1374,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1511,7 +1510,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1873,7 +1872,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -2359,7 +2358,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2402,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2520,7 +2519,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "candid",
  "serde",
@@ -2652,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "askama",
  "async-trait",
@@ -2787,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "k256",
  "lazy_static",
@@ -3106,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3272,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3280,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3494,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3597,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3887,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "bincode",
  "candid",
@@ -4209,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4351,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "cvt",
  "hex",
@@ -4368,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4446,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "async-trait",
  "candid",
@@ -4457,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "async-trait",
  "candid",
@@ -4483,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "base32",
  "candid",
@@ -4827,7 +4826,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -5150,7 +5149,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -5245,7 +5244,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -5257,7 +5256,7 @@ dependencies = [
  "proc-macro-crate 2.0.1",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -5478,9 +5477,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3163d2912b7c3b52d651a055f2c7eec9ba5cd22d26ef75b8dd3a59980b185923"
+checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
  "base64 0.21.5",
  "serde",
@@ -5532,7 +5531,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -5569,7 +5568,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#b098caefd5ed5583e5fd994bc270eead307783ff"
+source = "git+https://github.com/rvanasa/ic?branch=evm-rpc-canister#ffbb15ce5726aceec15224cc617514e832fd4085"
 dependencies = [
  "candid",
  "serde",
@@ -5618,7 +5617,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -5943,7 +5942,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -6091,7 +6090,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
- "pem 3.0.2",
+ "pem 3.0.3",
  "ring 0.16.20",
  "time",
  "yasna",
@@ -6577,7 +6576,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -6971,14 +6970,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
 name = "stubborn-io"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b261fbca19f25e0ac726f6efb3c3f53949e18ba4b126c16f8ca625730daa1a9c"
+checksum = "6363c4322e86e40291f94cf2f62cd8454ffd7abec426f63f11a6945f80718b43"
 dependencies = [
  "log",
  "rand",
@@ -7010,9 +7009,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.40"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7028,7 +7027,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -7185,7 +7184,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -7305,7 +7304,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -7494,7 +7493,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -7733,7 +7732,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -7765,7 +7764,7 @@ source = "git+https://github.com/rvanasa/wasm-bindgen?rev=62965b0749ca68237e2ab3
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8336,7 +8335,7 @@ checksum = "be912bf68235a88fbefd1b73415cb218405958d1655b2ece9035a19920bdf6ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -8356,5 +8355,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.41",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [profile.release]
 debug = false
 lto = true
-opt-level = 'z'
+opt-level = 's'
 
 # Required by `ic-test-utilities-load-wasm`
 [profile.canister-release]

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -1,12 +1,33 @@
 type Auth = variant { Rpc; RegisterProvider; FreeRpc; ManageService };
-type Block = record { baseFeePerGas : nat; number : nat };
-type BlockSpec = variant { Tag : BlockTag; Number : nat };
+type Block = record {
+  miner : text;
+  totalDifficulty : nat;
+  receiptsRoot : text;
+  stateRoot : text;
+  hash : text;
+  difficulty : nat;
+  size : nat;
+  uncles : vec text;
+  baseFeePerGas : nat;
+  extraData : text;
+  transactionsRoot : opt text;
+  sha3Uncles : text;
+  nonce : nat;
+  number : nat;
+  timestamp : nat;
+  transactions : vec text;
+  gasLimit : nat;
+  logsBloom : text;
+  parentHash : text;
+  gasUsed : nat;
+  mixHash : text;
+};
 type BlockTag = variant {
   Earliest;
   Safe;
   Finalized;
   Latest;
-  Number : nat64;
+  Number : nat;
   Pending;
 };
 type CandidRpcSource = variant {
@@ -22,16 +43,16 @@ type FeeHistory = record {
 };
 type FeeHistoryArgs = record {
   blockCount : nat;
-  newestBlock : BlockSpec;
+  newestBlock : BlockTag;
   rewardPercentiles : opt vec nat8;
 };
 type GetLogsArgs = record {
-  fromBlock : opt BlockSpec;
-  toBlock : opt BlockSpec;
+  fromBlock : opt BlockTag;
+  toBlock : opt BlockTag;
   addresses : vec text;
   topics : opt vec text;
 };
-type GetTransactionCountArgs = record { address : text; block : BlockSpec };
+type GetTransactionCountArgs = record { address : text; block : BlockTag };
 type HttpHeader = record { value : text; name : text };
 type HttpOutcallError = variant {
   IcError : record { code : RejectionCode; message : text };
@@ -117,14 +138,13 @@ type Source = variant {
   Provider : nat64;
 };
 type TransactionReceipt = record {
-  status : TransactionStatus;
+  status : nat;
   transactionHash : text;
   blockNumber : nat;
   blockHash : text;
   effectiveGasPrice : nat;
   gasUsed : nat;
 };
-type TransactionStatus = variant { Success; Failure };
 type UpdateProviderArgs = record {
   cyclesPerCall : opt nat64;
   credentialPath : opt text;
@@ -145,7 +165,7 @@ service : {
   authorize : (principal, Auth) -> ();
   deauthorize : (principal, Auth) -> ();
   eth_feeHistory : (CandidRpcSource, FeeHistoryArgs) -> (Result);
-  eth_getBlockByNumber : (CandidRpcSource, BlockSpec) -> (Result_1);
+  eth_getBlockByNumber : (CandidRpcSource, BlockTag) -> (Result_1);
   eth_getLogs : (CandidRpcSource, GetLogsArgs) -> (Result_2);
   eth_getTransactionCount : (CandidRpcSource, GetTransactionCountArgs) -> (
       Result_3,

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -38,6 +38,7 @@ type EthMainnetService = variant { BlockPi; Cloudflare; PublicNode; Ankr };
 type EthSepoliaService = variant { BlockPi; PublicNode; Ankr };
 type FeeHistory = record {
   reward : vec vec nat;
+  gasUsedRatio : vec float64;
   oldestBlock : nat;
   baseFeePerGas : vec nat;
 };
@@ -138,11 +139,18 @@ type Source = variant {
   Provider : nat64;
 };
 type TransactionReceipt = record {
+  to : text;
   status : nat;
   transactionHash : text;
   blockNumber : nat;
+  from : text;
+  logs : vec LogEntry;
   blockHash : text;
+  "type" : text;
+  transactionIndex : nat;
   effectiveGasPrice : nat;
+  logsBloom : text;
+  contractAddress : opt text;
   gasUsed : nat;
 };
 type UpdateProviderArgs = record {

--- a/scripts/examples
+++ b/scripts/examples
@@ -15,6 +15,6 @@ dfx canister call $CANISTER_ID request "(variant {$JSON_SOURCE}, "'"{ \"jsonrpc\
 dfx canister call $CANISTER_ID eth_getLogs "(variant {$CANDID_SOURCE}, record {addresses = vec {\"0xdAC17F958D2ee523a2206206994597C13D831ec7\"}})" $FLAGS || exit 1
 dfx canister call $CANISTER_ID eth_getBlockByNumber "(variant {$CANDID_SOURCE}, variant {Latest})" $FLAGS || exit 1
 dfx canister call $CANISTER_ID eth_getTransactionReceipt "(variant {$CANDID_SOURCE}, \"0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f\")" $FLAGS || exit 1
-dfx canister call $CANISTER_ID eth_getTransactionCount "(variant {$CANDID_SOURCE}, record {address = \"0xdAC17F958D2ee523a2206206994597C13D831ec7\"; block = variant {Tag = variant {Latest}}})" $FLAGS || exit 1
-dfx canister call $CANISTER_ID eth_feeHistory "(variant {$CANDID_SOURCE}, record {blockCount = 3; newestBlock = variant {Tag = variant {Latest}}})" $FLAGS || exit 1
+dfx canister call $CANISTER_ID eth_getTransactionCount "(variant {$CANDID_SOURCE}, record {address = \"0xdAC17F958D2ee523a2206206994597C13D831ec7\"; block = variant {Latest}})" $FLAGS || exit 1
+dfx canister call $CANISTER_ID eth_feeHistory "(variant {$CANDID_SOURCE}, record {blockCount = 3; newestBlock = variant {Latest}})" $FLAGS || exit 1
 dfx canister call $CANISTER_ID eth_sendRawTransaction "(variant {$CANDID_SOURCE}, \"0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83\")" $FLAGS || exit 1

--- a/scripts/examples
+++ b/scripts/examples
@@ -13,7 +13,7 @@ FLAGS="--with-cycles=$CYCLES --wallet=$WALLET"
 dfx canister call $CANISTER_ID request "(variant {$JSON_SOURCE}, "'"{ \"jsonrpc\": \"2.0\", \"method\": \"eth_gasPrice\", \"params\": [], \"id\": 1 }"'", 1000)" $FLAGS || exit 1
 
 dfx canister call $CANISTER_ID eth_getLogs "(variant {$CANDID_SOURCE}, record {addresses = vec {\"0xdAC17F958D2ee523a2206206994597C13D831ec7\"}})" $FLAGS || exit 1
-dfx canister call $CANISTER_ID eth_getBlockByNumber "(variant {$CANDID_SOURCE}, variant {Tag=variant {Latest}})" $FLAGS || exit 1
+dfx canister call $CANISTER_ID eth_getBlockByNumber "(variant {$CANDID_SOURCE}, variant {Latest})" $FLAGS || exit 1
 dfx canister call $CANISTER_ID eth_getTransactionReceipt "(variant {$CANDID_SOURCE}, \"0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f\")" $FLAGS || exit 1
 dfx canister call $CANISTER_ID eth_getTransactionCount "(variant {$CANDID_SOURCE}, record {address = \"0xdAC17F958D2ee523a2206206994597C13D831ec7\"; block = variant {Tag = variant {Latest}}})" $FLAGS || exit 1
 dfx canister call $CANISTER_ID eth_feeHistory "(variant {$CANDID_SOURCE}, record {blockCount = 3; newestBlock = variant {Tag = variant {Latest}}})" $FLAGS || exit 1

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -129,10 +129,7 @@ impl CandidRpcClient {
         wrap_result(self.client.eth_get_logs(args).await)
     }
 
-    pub async fn eth_get_block_by_number(
-        &self,
-        block: candid_types::BlockTag,
-    ) -> RpcResult<Block> {
+    pub async fn eth_get_block_by_number(&self, block: candid_types::BlockTag) -> RpcResult<Block> {
         wrap_result(self.client.eth_get_block_by_number(block.into()).await)
     }
 

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -36,7 +36,7 @@ impl RpcTransport for CanisterTransport {
                     EthMainnetService::Ankr => ANKR_HOSTNAME,
                     EthMainnetService::BlockPi => BLOCKPI_ETH_MAINNET_HOSTNAME,
                     EthMainnetService::PublicNode => PUBLICNODE_ETH_MAINNET_HOSTNAME,
-                    EthMainnetService::Cloudflare => CLOUDFLARE_ETH_HOSTNAME,
+                    EthMainnetService::Cloudflare => CLOUDFLARE_HOSTNAME,
                 },
             ),
             EthSepolia(provider) => (

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -131,7 +131,7 @@ impl CandidRpcClient {
 
     pub async fn eth_get_block_by_number(
         &self,
-        block: candid_types::BlockSpec,
+        block: candid_types::BlockTag,
     ) -> RpcResult<Block> {
         wrap_result(self.client.eth_get_block_by_number(block.into()).await)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ pub async fn eth_get_logs(
 #[candid_method(rename = "eth_getBlockByNumber")]
 pub async fn eth_get_block_by_number(
     source: CandidRpcSource,
-    block: candid_types::BlockSpec,
+    block: candid_types::BlockTag,
 ) -> RpcResult<Block> {
     CandidRpcClient::from_source(source)?
         .eth_get_block_by_number(block)

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-pub const CLOUDFLARE_ETH_HOSTNAME: &str = "cloudflare-eth.com";
+pub const CLOUDFLARE_HOSTNAME: &str = "cloudflare-eth.com";
 pub const ANKR_HOSTNAME: &str = "rpc.ankr.com";
 pub const PUBLICNODE_ETH_MAINNET_HOSTNAME: &str = "ethereum.publicnode.com";
 pub const BLOCKPI_ETH_MAINNET_HOSTNAME: &str = "ethereum.blockpi.network";
@@ -12,7 +12,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
     vec![
         RegisterProviderArgs {
             chain_id: ETH_MAINNET_CHAIN_ID,
-            hostname: CLOUDFLARE_ETH_HOSTNAME.to_string(),
+            hostname: CLOUDFLARE_HOSTNAME.to_string(),
             credential_path: "/v1/mainnet".to_string(),
             credential_headers: None,
             cycles_per_call: 0,
@@ -27,7 +27,7 @@ pub fn get_default_providers() -> Vec<RegisterProviderArgs> {
             cycles_per_message_byte: 0,
         },
         RegisterProviderArgs {
-            chain_id: ETH_SEPOLIA_CHAIN_ID,
+            chain_id: ETH_MAINNET_CHAIN_ID,
             hostname: PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string(),
             credential_path: "".to_string(),
             credential_headers: None,

--- a/src/types.rs
+++ b/src/types.rs
@@ -354,22 +354,6 @@ pub mod candid_types {
 
     pub use cketh_common::eth_rpc::Hash;
 
-    #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
-    pub enum BlockSpec {
-        Number(u128),
-        Tag(BlockTag),
-    }
-
-    impl From<BlockSpec> for cketh_common::eth_rpc::BlockSpec {
-        fn from(value: BlockSpec) -> Self {
-            use cketh_common::eth_rpc::BlockSpec::*;
-            match value {
-                BlockSpec::Number(n) => Number(n.into()),
-                BlockSpec::Tag(t) => Tag(t.into()),
-            }
-        }
-    }
-
     #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Default)]
     pub enum BlockTag {
         #[default]
@@ -378,17 +362,20 @@ pub mod candid_types {
         Safe,
         Earliest,
         Pending,
-        Number(u64),
+        Number(BlockNumber),
     }
 
-    impl From<BlockTag> for cketh_common::eth_rpc::BlockTag {
-        fn from(value: BlockTag) -> cketh_common::eth_rpc::BlockTag {
+    impl From<BlockTag> for cketh_common::eth_rpc::BlockSpec {
+        fn from(value: BlockTag) -> Self {
+            use cketh_common::eth_rpc::BlockSpec::*;
             use cketh_common::eth_rpc::BlockTag::*;
             match value {
-                BlockTag::Latest => Latest,
-                BlockTag::Safe => Safe,
-                BlockTag::Finalized => Finalized,
-                _ => unimplemented!(),
+                BlockTag::Number(n) => Number(n),
+                BlockTag::Latest => Tag(Latest),
+                BlockTag::Safe => Tag(Safe),
+                BlockTag::Finalized => Tag(Finalized),
+                BlockTag::Earliest => Tag(Earliest),
+                BlockTag::Pending => Tag(Pending),
             }
         }
     }
@@ -396,9 +383,9 @@ pub mod candid_types {
     #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
     pub struct GetLogsArgs {
         #[serde(rename = "fromBlock")]
-        pub from_block: Option<BlockSpec>,
+        pub from_block: Option<BlockTag>,
         #[serde(rename = "toBlock")]
-        pub to_block: Option<BlockSpec>,
+        pub to_block: Option<BlockTag>,
         pub addresses: Vec<String>,
         pub topics: Option<Vec<String>>,
     }
@@ -459,7 +446,7 @@ pub mod candid_types {
         #[serde(rename = "blockCount")]
         pub block_count: u128,
         #[serde(rename = "newestBlock")]
-        pub newest_block: BlockSpec,
+        pub newest_block: BlockTag,
         #[serde(rename = "rewardPercentiles")]
         pub reward_percentiles: Option<Vec<u8>>,
     }
@@ -477,7 +464,7 @@ pub mod candid_types {
     #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize)]
     pub struct GetTransactionCountArgs {
         pub address: String,
-        pub block: BlockSpec,
+        pub block: BlockTag,
     }
 
     impl TryFrom<GetTransactionCountArgs>

--- a/src/types.rs
+++ b/src/types.rs
@@ -426,6 +426,16 @@ pub mod candid_types {
         pub status: candid::Nat,
         #[serde(rename = "transactionHash")]
         pub transaction_hash: String,
+        #[serde(rename = "contractAddress")]
+        pub contract_address: Option<String>,
+        pub from: String,
+        pub logs: Vec<cketh_common::eth_rpc::LogEntry>,
+        #[serde(rename = "logsBloom")]
+        pub logs_bloom: String,
+        pub to: String,
+        #[serde(rename = "transactionIndex")]
+        pub transaction_index: candid::Nat,
+        pub r#type: String,
     }
 
     impl From<cketh_common::eth_rpc_client::responses::TransactionReceipt> for TransactionReceipt {
@@ -437,6 +447,13 @@ pub mod candid_types {
                 gas_used: into_nat(value.gas_used.into_inner()),
                 status: (value.status as u64).into(),
                 transaction_hash: format!("{:#x}", value.transaction_hash),
+                contract_address: value.contract_address,
+                from: value.from,
+                logs: value.logs,
+                logs_bloom: value.logs_bloom,
+                to: value.to,
+                transaction_index: into_nat(value.transaction_index.into_inner()),
+                r#type: value.r#type,
             }
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -445,7 +445,7 @@ pub mod candid_types {
                 block_number: value.block_number,
                 effective_gas_price: into_nat(value.effective_gas_price.into_inner()),
                 gas_used: into_nat(value.gas_used.into_inner()),
-                status: (value.status as u64).into(),
+                status: into_nat(value.status.into()),
                 transaction_hash: format!("{:#x}", value.transaction_hash),
                 contract_address: value.contract_address,
                 from: value.from,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -222,7 +222,7 @@ impl EvmRpcSetup {
     pub fn eth_get_block_by_number(
         &self,
         source: CandidRpcSource,
-        block: candid_types::BlockSpec,
+        block: candid_types::BlockTag,
     ) -> CallFlow<RpcResult<Block>> {
         self.call_update("eth_getBlockByNumber", Encode!(&source, &block).unwrap())
     }
@@ -699,15 +699,34 @@ fn eth_get_block_by_number_should_succeed() {
     let response = setup
         .eth_get_block_by_number(
             CandidRpcSource::EthMainnet(None),
-            candid_types::BlockSpec::Tag(candid_types::BlockTag::Latest),
+            candid_types::BlockTag::Latest,
         )
         .mock_http(MockOutcallBuilder::new(200, r#"{"jsonrpc":"2.0","result":{"baseFeePerGas":"0xd7232aa34","difficulty":"0x0","extraData":"0x546974616e2028746974616e6275696c6465722e78797a29","gasLimit":"0x1c9c380","gasUsed":"0xa768c4","hash":"0xc3674be7b9d95580d7f23c03d32e946f2b453679ee6505e3a778f003c5a3cfae","logsBloom":"0x3e6b8420e1a13038902c24d6c2a9720a7ad4860cdc870cd5c0490011e43631134f608935bd83171247407da2c15d85014f9984608c03684c74aad48b20bc24022134cdca5f2e9d2dee3b502a8ccd39eff8040b1d96601c460e119c408c620b44fa14053013220847045556ea70484e67ec012c322830cf56ef75e09bd0db28a00f238adfa587c9f80d7e30d3aba2863e63a5cad78954555966b1055a4936643366a0bb0b1bac68d0e6267fc5bf8304d404b0c69041125219aa70562e6a5a6362331a414a96d0716990a10161b87dd9568046a742d4280014975e232b6001a0360970e569d54404b27807d7a44c949ac507879d9d41ec8842122da6772101bc8b","miner":"0x388c818ca8b9251b393131c08a736a67ccb19297","mixHash":"0x516a58424d4883a3614da00a9c6f18cd5cd54335a08388229a993a8ecf05042f","nonce":"0x0000000000000000","number":"0x11db01d","parentHash":"0x43325027f6adf9befb223f8ae80db057daddcd7b48e41f60cd94bfa8877181ae","receiptsRoot":"0x66934c3fd9c547036fe0e56ad01bc43c84b170be7c4030a86805ddcdab149929","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0xcd35","stateRoot":"0x13552447dd62f11ad885f21a583c4fa34144efe923c7e35fb018d6710f06b2b6","timestamp":"0x656f96f3","totalDifficulty":"0xc70d815d562d3cfa955","withdrawalsRoot":"0xecae44b2c53871003c5cc75285995764034c9b5978a904229d36c1280b141d48"},"id":0}"#))
         .wait().unwrap();
     assert_eq!(
         response,
         Block {
-            number: BlockNumber::new(18_722_845),
             base_fee_per_gas: Wei::new(57_750_497_844),
+            difficulty: CheckedAmountOf::new(0),
+            extra_data: "0x546974616e2028746974616e6275696c6465722e78797a29".to_string(),
+            gas_limit: CheckedAmountOf::new(0x1c9c380),
+            gas_used: CheckedAmountOf::new(0xa768c4),
+            hash: "0xc3674be7b9d95580d7f23c03d32e946f2b453679ee6505e3a778f003c5a3cfae".to_string(),
+            logs_bloom: "0x3e6b8420e1a13038902c24d6c2a9720a7ad4860cdc870cd5c0490011e43631134f608935bd83171247407da2c15d85014f9984608c03684c74aad48b20bc24022134cdca5f2e9d2dee3b502a8ccd39eff8040b1d96601c460e119c408c620b44fa14053013220847045556ea70484e67ec012c322830cf56ef75e09bd0db28a00f238adfa587c9f80d7e30d3aba2863e63a5cad78954555966b1055a4936643366a0bb0b1bac68d0e6267fc5bf8304d404b0c69041125219aa70562e6a5a6362331a414a96d0716990a10161b87dd9568046a742d4280014975e232b6001a0360970e569d54404b27807d7a44c949ac507879d9d41ec8842122da6772101bc8b".to_string(),
+            miner: "0x388c818ca8b9251b393131c08a736a67ccb19297".to_string(),
+            mix_hash: "0x516a58424d4883a3614da00a9c6f18cd5cd54335a08388229a993a8ecf05042f".to_string(),
+            nonce: CheckedAmountOf::new(0),
+            number: BlockNumber::new(18_722_845),
+            parent_hash: "0x43325027f6adf9befb223f8ae80db057daddcd7b48e41f60cd94bfa8877181ae".to_string(),
+            receipts_root: "0x66934c3fd9c547036fe0e56ad01bc43c84b170be7c4030a86805ddcdab149929".to_string(),
+            sha3_uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347".to_string(),
+            size: CheckedAmountOf::new(0xcd35),
+            state_root: "0x13552447dd62f11ad885f21a583c4fa34144efe923c7e35fb018d6710f06b2b6".to_string(),
+            timestamp: CheckedAmountOf::new(0x656f96f3),
+            total_difficulty: CheckedAmountOf::new(0xc70d815d562d3cfa955),
+            transactions: vec![],
+            transactions_root: None,
+            uncles: vec![],
         }
     );
 }
@@ -745,7 +764,7 @@ fn eth_get_transaction_count_should_succeed() {
             CandidRpcSource::EthMainnet(None),
             candid_types::GetTransactionCountArgs {
                 address: "0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
-                block: candid_types::BlockSpec::Tag(candid_types::BlockTag::Latest),
+                block: candid_types::BlockTag::Latest,
             },
         )
         .mock_http(MockOutcallBuilder::new(
@@ -765,7 +784,7 @@ fn eth_fee_history_should_succeed() {
             CandidRpcSource::EthMainnet(None),
             candid_types::FeeHistoryArgs {
                 block_count: 3,
-                newest_block: candid_types::BlockSpec::Tag(candid_types::BlockTag::Latest),
+                newest_block: candid_types::BlockTag::Latest,
                 reward_percentiles: None,
             },
         )

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -845,7 +845,7 @@ fn candid_rpc_should_allow_unexpected_response_fields() {
             CandidRpcSource::EthMainnet(None),
             "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f",
         )
-        .mock_http(MockOutcallBuilder::new(200, r#"{"jsonrpc":"2.0","id":0,"result":{"unexpectedKey":"unexpectedValue","blockHash":"0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35","blockNumber":"0x5bad55","contractAddress":null,"cumulativeGasUsed":"0xb90b0","effectiveGasPrice":"0x746a528800","from":"0x398137383b3d25c92898c656696e41950e47316b","gasUsed":"0x1383f","logs":[],"status":"0x1","to":"0x06012c8cf97bead5deae237070f9587f8e7a266d","transactionHash":"0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0","transactionIndex":"0x11","type":"0x0"}}"#))
+        .mock_http(MockOutcallBuilder::new(200, r#"{"jsonrpc":"2.0","id":0,"result":{"unexpectedKey":"unexpectedValue","blockHash":"0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35","blockNumber":"0x5bad55","contractAddress":null,"cumulativeGasUsed":"0xb90b0","effectiveGasPrice":"0x746a528800","from":"0x398137383b3d25c92898c656696e41950e47316b","gasUsed":"0x1383f","logs":[],"logsBloom":"0x0","status":"0x1","to":"0x06012c8cf97bead5deae237070f9587f8e7a266d","transactionHash":"0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0","transactionIndex":"0x11","type":"0x0"}}"#))
         .wait().unwrap().expect("receipt was None");
     assert_eq!(
         response.block_hash,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -630,11 +630,18 @@ fn should_decode_transaction_receipt() {
         status: 0.into(),
         transaction_hash: "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f"
             .to_string(),
+        contract_address: None,
         block_number: 18_515_371_u64.into(),
         block_hash: "0x5115c07eb1f20a9d6410db0916ed3df626cfdab161d3904f45c8c8b65c90d0be"
             .to_string(),
         effective_gas_price: 26_776_497_782_u64.into(),
         gas_used: 32_137.into(),
+        from: "0x0aa8ebb6ad5a8e499e550ae2c461197624c6e667".to_string(),
+        logs: vec![],
+        logs_bloom: "0x0".to_string(),
+        to: "0x356cfd6e6d0000400000003900b415f80669009e".to_string(),
+        transaction_index: 0xd9.into(),
+        r#type: "0x2".to_string(),
     };
     assert_eq!(
         Decode!(&Encode!(&value).unwrap(), candid_types::TransactionReceipt).unwrap(),
@@ -744,14 +751,19 @@ fn eth_get_transaction_receipt_should_succeed() {
     assert_eq!(
         response,
         Some(candid_types::TransactionReceipt {
-            status: 0.into(),
-            transaction_hash: "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f"
-                .to_string(),
-            block_number: 18_515_371_u64.into(),
-            block_hash: "0x5115c07eb1f20a9d6410db0916ed3df626cfdab161d3904f45c8c8b65c90d0be"
-                .to_string(),
-            effective_gas_price: 26_776_497_782_u64.into(),
-            gas_used: 32_137.into(),
+            status: 0x1.into(),
+            transaction_hash: "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f".to_string(),
+            contract_address:None,
+            block_number: 0x11a85ab_u64.into(),
+            block_hash: "0x5115c07eb1f20a9d6410db0916ed3df626cfdab161d3904f45c8c8b65c90d0be".to_string(),
+            effective_gas_price: 0x63c00ee76_u64.into(),
+            gas_used: 0x7d89.into(),
+            from: "0x0aa8ebb6ad5a8e499e550ae2c461197624c6e667".to_string(),
+            logs: vec![],
+            logs_bloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            to: "0x356cfd6e6d0000400000003900b415f80669009e".to_string(),
+            transaction_index: 0xd9.into(),
+            r#type: "0x2".to_string(),
         })
     );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -753,7 +753,7 @@ fn eth_get_transaction_receipt_should_succeed() {
         Some(candid_types::TransactionReceipt {
             status: 0x1.into(),
             transaction_hash: "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f".to_string(),
-            contract_address:None,
+            contract_address: None,
             block_number: 0x11a85ab_u64.into(),
             block_hash: "0x5115c07eb1f20a9d6410db0916ed3df626cfdab161d3904f45c8c8b65c90d0be".to_string(),
             effective_gas_price: 0x63c00ee76_u64.into(),
@@ -814,6 +814,7 @@ fn eth_fee_history_should_succeed() {
                 .into_iter()
                 .map(|hex| CheckedAmountOf::from_str_hex(hex).unwrap())
                 .collect(),
+            gas_used_ratio: vec![],
             reward: vec![vec![CheckedAmountOf::new(0x0123)]],
         })
     );

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -627,7 +627,7 @@ fn should_decode_address() {
 #[test]
 fn should_decode_transaction_receipt() {
     let value = candid_types::TransactionReceipt {
-        status: 0.into(),
+        status: 0x1.into(),
         transaction_hash: "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f"
             .to_string(),
         contract_address: None,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -443,7 +443,7 @@ fn should_register_provider() {
     let b_id = setup
         .register_provider(RegisterProviderArgs {
             chain_id: 5,
-            hostname: CLOUDFLARE_ETH_HOSTNAME.to_string(),
+            hostname: CLOUDFLARE_HOSTNAME.to_string(),
             credential_path: "/test-path".to_string(),
             credential_headers: Some(vec![HttpHeader {
                 name: "Test-Authorization".to_string(),
@@ -473,7 +473,7 @@ fn should_register_provider() {
                 provider_id: first_new_id + 1,
                 owner: setup.caller.0,
                 chain_id: 5,
-                hostname: CLOUDFLARE_ETH_HOSTNAME.to_string(),
+                hostname: CLOUDFLARE_HOSTNAME.to_string(),
                 cycles_per_call: 0,
                 cycles_per_message_byte: 0,
                 primary: false,


### PR DESCRIPTION
Previously, the EVM RPC canister only returned JSON object properties used in ckETH. This PR adds the corresponding Candid record fields for all remaining properties. 