### PR TITLE
chore: set up mainnet E2E testing environment

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,4 +1,10 @@
 {
+  "e2e_motoko": {
+    "ic": "rcfjk-jiaaa-aaaap-abuoq-cai"
+  },
+  "e2e_rust": {
+    "ic": "rlgcw-7aaaa-aaaap-abupa-cai"
+  },
   "evm_rpc": {
     "ic": "a6d44-nyaaa-aaaap-abp7q-cai"
   },

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -6,7 +6,7 @@ import Debug "mo:base/Debug";
 import Text "mo:base/Text";
 import Blob "mo:base/Blob";
 
-actor class Main() {
+shared ({ caller = installer }) actor class Main() {
     let mainnet = Evm.Rpc(
         #Canister EvmRpcCanister,
         #Service {
@@ -16,6 +16,8 @@ actor class Main() {
     );
 
     public shared ({ caller }) func test() : async () {
+        assert caller == installer;
+
         let source = #Service {
             hostname = "cloudflare-eth.com";
             chainId = ?(1 : Nat64); // Ethereum mainnet

--- a/e2e/rust/src/main.rs
+++ b/e2e/rust/src/main.rs
@@ -8,6 +8,8 @@ fn main() {}
 #[update]
 #[candid_method(update)]
 pub async fn test() {
+    assert!(ic_cdk::api::is_controller(&ic_cdk::caller()));
+
     // Define request parameters
     let params = (
         &Source::Service {


### PR DESCRIPTION
This PR adds access control to the Rust and Motoko E2E tests and includes the deployed principals in `canister_ids.json`. 

Resolves #78.