### PR TITLE
refactor: convert `payload_size_bytes` from `usize` to `u64`

### DIFF
--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -39,7 +39,7 @@ impl RpcTransport for CanisterTransport {
             request
                 .body
                 .as_ref()
-                .map(|bytes| bytes.len())
+                .map(|bytes| bytes.len() as u64)
                 .unwrap_or_default(),
             effective_response_size_estimate,
         );

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,7 +19,7 @@ pub async fn do_json_rpc_request(
         add_metric!(err_no_permission, 1);
         return Err(ProviderError::NoPermission.into());
     }
-    let cycles_cost = get_json_rpc_cost(&source, json_rpc_payload.len(), max_response_bytes);
+    let cycles_cost = get_json_rpc_cost(&source, json_rpc_payload.len() as u64, max_response_bytes);
     let (api, provider) = match source {
         ResolvedJsonRpcSource::Api(api) => (api, None),
         ResolvedJsonRpcSource::Provider(provider) => (provider.api(), Some(provider)),
@@ -81,7 +81,7 @@ pub async fn do_http_request_with_metrics(
                 request
                     .body
                     .as_ref()
-                    .map(|bytes| bytes.len())
+                    .map(|bytes| bytes.len() as u64)
                     .unwrap_or_default(),
             );
             PROVIDERS.with(|p| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn request_cost(
 ) -> Result<u128, RpcError> {
     Ok(get_json_rpc_cost(
         &source.resolve().unwrap(),
-        json_rpc_payload.len(),
+        json_rpc_payload.len() as u64,
         max_response_bytes,
     ))
 }


### PR DESCRIPTION
Follow-up from #86. 

This adds some minor performance overhead in exchange for a slightly cleaner codebase. 