### PR TITLE
fix: change case of metric fields in Candid interface

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -84,12 +84,12 @@ type Message = variant { Data : blob; Hash : blob };
 type Metrics = record {
   requests : vec record { record { text; text }; nat64 };
   responses : vec record { record { text; text }; nat64 };
-  cycles_charged : vec record { record { text; text }; nat };
-  cycles_withdrawn : nat;
-  err_no_permission : nat64;
-  err_http_outcall : vec record { record { text; text }; nat64 };
-  err_http_response : vec record { record { text; text }; nat64 };
-  err_host_not_allowed : vec record { text; nat64 };
+  cyclesCharged : vec record { record { text; text }; nat };
+  cyclesWithdrawn : nat;
+  errNoPermission : nat64;
+  errHttpOutcall : vec record { record { text; text }; nat64 };
+  errHttpResponse : vec record { record { text; text }; nat64 };
+  errHostNotAllowed : vec record { text; nat64 };
 };
 type MultiFeeHistoryResult = variant {
   Consistent : FeeHistoryResult;

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,11 +137,17 @@ impl MetricLabels for RpcHost {
 pub struct Metrics {
     pub requests: HashMap<(RpcMethod, RpcHost), u64>,
     pub responses: HashMap<(RpcMethod, RpcHost), u64>,
+    #[serde(rename = "cyclesCharged")]
     pub cycles_charged: HashMap<(RpcMethod, RpcHost), u128>,
+    #[serde(rename = "cyclesWithdrawn")]
     pub cycles_withdrawn: u128,
+    #[serde(rename = "errNoPermission")]
     pub err_no_permission: u64,
+    #[serde(rename = "errHostNotAllowed")]
     pub err_host_not_allowed: HashMap<RpcHost, u64>,
+    #[serde(rename = "errHttpOutcall")]
     pub err_http_outcall: HashMap<(RpcMethod, RpcHost), u64>,
+    #[serde(rename = "errHttpResponse")]
     pub err_http_response: HashMap<(RpcMethod, RpcHost), u64>,
 }
 


### PR DESCRIPTION
This PR adjusts the fields in the `Metrics` record to use camelCase instead of snake_case for consistency with the RPC methods and canister install arguments. 