### PR TITLE
refactor: rename `ManageCanister` authorization to `Manage`

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -1,4 +1,4 @@
-type Auth = variant { FreeRpc; PriorityRpc; RegisterProvider; ManageCanister };
+type Auth = variant { FreeRpc; PriorityRpc; RegisterProvider; Manage };
 type Block = record {
   miner : text;
   totalDifficulty : nat;

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -14,7 +14,7 @@ pub fn is_authorized(principal: &Principal, auth: Auth) -> bool {
 
 pub fn require_admin_or_controller() -> Result<(), String> {
     let caller = ic_cdk::caller();
-    if is_authorized(&caller, Auth::ManageCanister) || ic_cdk::api::is_controller(&caller) {
+    if is_authorized(&caller, Auth::Manage) || ic_cdk::api::is_controller(&caller) {
         Ok(())
     } else {
         Err("You are not authorized".to_string())
@@ -87,9 +87,9 @@ fn test_authorization() {
     do_deauthorize(principal1, Auth::RegisterProvider);
     assert!(!is_authorized(&principal1, Auth::RegisterProvider));
 
-    do_authorize(principal2, Auth::ManageCanister);
-    assert!(!is_authorized(&principal1, Auth::ManageCanister));
-    assert!(is_authorized(&principal2, Auth::ManageCanister));
+    do_authorize(principal2, Auth::Manage);
+    assert!(!is_authorized(&principal1, Auth::Manage));
+    assert!(is_authorized(&principal2, Auth::Manage));
 
     assert!(!is_authorized(&principal2, Auth::PriorityRpc));
     assert!(!is_authorized(&principal2, Auth::RegisterProvider));

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -147,7 +147,7 @@ pub fn do_unregister_provider(caller: Principal, provider_id: u64) -> bool {
     PROVIDERS.with(|p| {
         let mut p = p.borrow_mut();
         if let Some(provider) = p.get(&provider_id) {
-            if provider.owner == caller || is_authorized(&caller, Auth::ManageCanister) {
+            if provider.owner == caller || is_authorized(&caller, Auth::Manage) {
                 p.remove(&provider_id).is_some()
             } else {
                 ic_cdk::trap("Not authorized");
@@ -163,7 +163,7 @@ pub fn do_update_provider(caller: Principal, update: UpdateProviderArgs) {
         let mut p = p.borrow_mut();
         match p.get(&update.provider_id) {
             Some(mut provider) => {
-                if provider.owner != caller && !is_authorized(&caller, Auth::ManageCanister) {
+                if provider.owner != caller && !is_authorized(&caller, Auth::Manage) {
                     ic_cdk::trap("Provider owner != caller");
                 }
                 if let Some(hostname) = update.hostname {

--- a/src/types.rs
+++ b/src/types.rs
@@ -153,7 +153,7 @@ pub struct Metrics {
 
 #[derive(Clone, Copy, Debug, PartialEq, CandidType, Serialize, Deserialize)]
 pub enum Auth {
-    ManageCanister,
+    Manage,
     RegisterProvider,
     PriorityRpc,
     FreeRpc,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -533,7 +533,7 @@ fn should_panic_if_unauthorized_update_provider() {
 #[test]
 #[should_panic(expected = "Not authorized")]
 fn should_panic_if_unauthorized_unregister_provider() {
-    // Only the `ManageCanister` authorization may unregister a provider
+    // Only the `Manage` authorization may unregister a provider
     let setup = EvmRpcSetup::new().authorize_caller(Auth::RegisterProvider);
     setup.unregister_provider(0);
 }
@@ -1156,7 +1156,7 @@ fn candid_rpc_should_handle_already_known() {
 #[test]
 #[should_panic(expected = "You are not authorized")]
 fn should_panic_if_unauthorized_set_rpc_access() {
-    // Only `ManageCanister` can restrict RPC access
+    // Only `Manage` can restrict RPC access
     let setup = EvmRpcSetup::new();
     setup.set_open_rpc_access(false);
 }


### PR DESCRIPTION
Open to other naming suggestions! 

Follow-up from #122.