### PR TITLE
metrics: HTTP status codes and inconsistent responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "candid",
  "serde",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "askama",
  "async-trait",
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "k256",
  "lazy_static",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3272,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "bincode",
  "candid",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4351,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "cvt",
  "hex",
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "async-trait",
  "candid",
@@ -4457,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "async-trait",
  "candid",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "base32",
  "candid",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
+source = "git+https://github.com/rvanasa/ic?rev=944c116a707cd739ae6304fa1cb6be7080e2c0e1#944c116a707cd739ae6304fa1cb6be7080e2c0e1"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "candid",
  "serde",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "askama",
  "async-trait",
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "k256",
  "lazy_static",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3272,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "sha3 0.9.1",
 ]
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3887,7 +3887,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "bincode",
  "candid",
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4351,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "cvt",
  "hex",
@@ -4368,7 +4368,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "async-trait",
  "candid",
@@ -4457,7 +4457,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "async-trait",
  "candid",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "base32",
  "candid",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f#cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f"
+source = "git+https://github.com/rvanasa/ic?rev=213fad6bfce710f44dcdcc54604c1849ad31c085#213fad6bfce710f44dcdcc54604c1849ad31c085"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-eth = { workspace = true }
-cketh-common = { git = "https://github.com/rvanasa/ic", rev = "cd3beda5a3bb3ea8f087b1a7bbd666dd557fbb6f", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/rvanasa/ic", rev = "c408ac3489a6a18a09b95e678cd16782db766c39", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"
@@ -39,18 +39,18 @@ async-trait = "0.1"
 hex = "0.4"
 
 [dev-dependencies]
-ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
-ic-config = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
-ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
-ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
+ic-config = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
+ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
+ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
 assert_matches = "1.5"
 
 [workspace.dependencies]
 candid = { version = "0.9" }
-ic-canister-log = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
-ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-canister-log = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
+ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
 ic-metrics-encoder = "1.1"
 ic-stable-structures = "0.5"
 ic-certified-map = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-eth = { workspace = true }
-cketh-common = { git = "https://github.com/rvanasa/ic", rev = "213fad6bfce710f44dcdcc54604c1849ad31c085", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/rvanasa/ic", rev = "944c116a707cd739ae6304fa1cb6be7080e2c0e1", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-eth = { workspace = true }
-cketh-common = { git = "https://github.com/rvanasa/ic", rev = "c408ac3489a6a18a09b95e678cd16782db766c39", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/rvanasa/ic", rev = "213fad6bfce710f44dcdcc54604c1849ad31c085", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"
@@ -39,18 +39,18 @@ async-trait = "0.1"
 hex = "0.4"
 
 [dev-dependencies]
-ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
-ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
-ic-config = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
-ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
-ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
+ic-ic00-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-base-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-config = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-state-machine-tests = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-test-utilities-load-wasm = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 assert_matches = "1.5"
 
 [workspace.dependencies]
 candid = { version = "0.9" }
-ic-canister-log = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
-ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
-ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2024-01-03_23-01" }
+ic-canister-log = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-canisters-http-types = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
+ic-nervous-system-common = { git = "https://github.com/dfinity/ic", rev = "release-2023-09-27_23-01" }
 ic-metrics-encoder = "1.1"
 ic-stable-structures = "0.5"
 ic-certified-map = "0.4"

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -83,15 +83,13 @@ type LogEntry = record {
 type Message = variant { Data : blob; Hash : blob };
 type Metrics = record {
   requests : vec record { record { text; text }; nat64 };
-  responses : vec record { record { text; text }; nat64 };
+  responses : vec record { record { text; text; text }; nat64 };
   inconsistentResponses : vec record { record { text; text }; nat64 };
   cyclesCharged : vec record { record { text; text }; nat };
   cyclesWithdrawn : nat;
   errNoPermission : nat64;
   errHttpOutcall : vec record { record { text; text }; nat64 };
-  errHttpResponse : vec record { record { text; text }; nat64 };
   errHostNotAllowed : vec record { text; nat64 };
-  errRateLimit : vec record { text; nat64 };
 };
 type MultiFeeHistoryResult = variant {
   Consistent : FeeHistoryResult;

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -84,6 +84,7 @@ type Message = variant { Data : blob; Hash : blob };
 type Metrics = record {
   requests : vec record { record { text; text }; nat64 };
   responses : vec record { record { text; text }; nat64 };
+  inconsistentResponses : vec record { record { text; text }; nat64 };
   cyclesCharged : vec record { record { text; text }; nat };
   cyclesWithdrawn : nat;
   errNoPermission : nat64;

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -90,6 +90,7 @@ type Metrics = record {
   errHttpOutcall : vec record { record { text; text }; nat64 };
   errHttpResponse : vec record { record { text; text }; nat64 };
   errHostNotAllowed : vec record { text; nat64 };
+  errRateLimit : vec record { text; nat64 };
 };
 type MultiFeeHistoryResult = variant {
   Consistent : FeeHistoryResult;

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -132,13 +132,12 @@ fn process_result<T>(method: RpcMethod, result: Result<T, MultiCallError<T>>) ->
             MultiCallError::ConsistentError(err) => MultiRpcResult::Consistent(Err(err)),
             MultiCallError::InconsistentResults(multi_call_results) => {
                 multi_call_results.results.iter().for_each(|(service, _)| {
-                    match resolve_provider(service) {
-                        Ok(provider) => add_metric_entry!(
+                    if let Ok(provider) = resolve_provider(service) {
+                        add_metric_entry!(
                             inconsistent_responses,
                             (method.into(), MetricRpcHost(provider.hostname)),
                             1
-                        ),
-                        Err(_) => {}
+                        )
                     }
                 });
                 MultiRpcResult::Inconsistent(multi_call_results.results.into_iter().collect())

--- a/src/http.rs
+++ b/src/http.rs
@@ -11,7 +11,7 @@ use crate::*;
 pub async fn do_json_rpc_request(
     caller: Principal,
     source: ResolvedJsonRpcSource,
-    rpc_method: RpcMethod,
+    rpc_method: MetricRpcMethod,
     json_rpc_payload: &str,
     max_response_bytes: u64,
 ) -> RpcResult<HttpResponse> {
@@ -48,14 +48,14 @@ pub async fn do_json_rpc_request(
             vec![],
         )),
     };
-    let rpc_host = RpcHost(host.to_string());
+    let rpc_host = MetricRpcHost(host.to_string());
     do_http_request_with_metrics(caller, rpc_method, rpc_host, provider, request, cycles_cost).await
 }
 
 pub async fn do_http_request_with_metrics(
     caller: Principal,
-    rpc_method: RpcMethod,
-    rpc_host: RpcHost,
+    rpc_method: MetricRpcMethod,
+    rpc_host: MetricRpcHost,
     provider: Option<Provider>,
     request: CanisterHttpRequestArgument,
     cycles_cost: u128,

--- a/src/http.rs
+++ b/src/http.rs
@@ -101,10 +101,11 @@ pub async fn do_http_request_with_metrics(
     match ic_cdk::api::management_canister::http_request::http_request(request, cycles_cost).await {
         Ok((response,)) => {
             let status: u32 = response.status.0.clone().try_into().unwrap_or(0);
+            if !(200..300).contains(&status) {
+                add_metric_entry!(err_http_response, (rpc_method.clone(), rpc_host.clone()), 1);
+            }
             if response.status == 429 {
                 add_metric_entry!(err_rate_limit, rpc_host.clone(), 1);
-            } else if !(200..300).contains(&status) {
-                add_metric_entry!(err_http_response, (rpc_method.clone(), rpc_host.clone()), 1);
             }
             add_metric_entry!(responses, (rpc_method, rpc_host), 1);
             Ok(response)

--- a/src/http.rs
+++ b/src/http.rs
@@ -101,12 +101,7 @@ pub async fn do_http_request_with_metrics(
     match ic_cdk::api::management_canister::http_request::http_request(request, cycles_cost).await {
         Ok((response,)) => {
             let status: u32 = response.status.0.clone().try_into().unwrap_or(0);
-            if response.status == 429 {
-                add_metric_entry!(err_rate_limit, rpc_host.clone(), 1);
-            } else if !(200..300).contains(&status) {
-                add_metric_entry!(err_http_response, (rpc_method.clone(), rpc_host.clone()), 1);
-            }
-            add_metric_entry!(responses, (rpc_method, rpc_host), 1);
+            add_metric_entry!(responses, (rpc_method, rpc_host, status.into()), 1);
             Ok(response)
         }
         Err((code, message)) => {

--- a/src/http.rs
+++ b/src/http.rs
@@ -101,7 +101,9 @@ pub async fn do_http_request_with_metrics(
     match ic_cdk::api::management_canister::http_request::http_request(request, cycles_cost).await {
         Ok((response,)) => {
             let status: u32 = response.status.0.clone().try_into().unwrap_or(0);
-            if !(200..300).contains(&status) {
+            if response.status == 429 {
+                add_metric_entry!(err_rate_limit, rpc_host.clone(), 1);
+            } else if !(200..300).contains(&status) {
                 add_metric_entry!(err_http_response, (rpc_method.clone(), rpc_host.clone()), 1);
             }
             add_metric_entry!(responses, (rpc_method, rpc_host), 1);

--- a/src/http.rs
+++ b/src/http.rs
@@ -101,11 +101,10 @@ pub async fn do_http_request_with_metrics(
     match ic_cdk::api::management_canister::http_request::http_request(request, cycles_cost).await {
         Ok((response,)) => {
             let status: u32 = response.status.0.clone().try_into().unwrap_or(0);
-            if !(200..300).contains(&status) {
-                add_metric_entry!(err_http_response, (rpc_method.clone(), rpc_host.clone()), 1);
-            }
             if response.status == 429 {
                 add_metric_entry!(err_rate_limit, rpc_host.clone(), 1);
+            } else if !(200..300).contains(&status) {
+                add_metric_entry!(err_http_response, (rpc_method.clone(), rpc_host.clone()), 1);
             }
             add_metric_entry!(responses, (rpc_method, rpc_host), 1);
             Ok(response)

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ async fn request(
     let response = do_json_rpc_request(
         ic_cdk::caller(),
         source.resolve()?,
-        RpcMethod("request".to_string()),
+        MetricRpcMethod("request".to_string()),
         &json_rpc_payload,
         max_response_bytes,
     )

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -73,6 +73,11 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
             "Number of successful RPC responses",
         );
         w.encode_entries(
+            "inconsistent_responses",
+            &m.inconsistent_responses,
+            "Number of inconsistent RPC responses",
+        );
+        w.encode_entries(
             "cycles_charged",
             &m.cycles_charged,
             "Number of cycles charged for RPC calls",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -66,12 +66,8 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
     crate::UNSTABLE_METRICS.with(|m| {
         let m = m.borrow();
 
-        w.encode_entries("requests", &m.requests, "Number of RPC requests");
-        w.encode_entries(
-            "responses",
-            &m.responses,
-            "Number of successful RPC responses",
-        );
+        w.encode_entries("requests", &m.requests, "Number of JSON-RPC requests");
+        w.encode_entries("responses", &m.responses, "Number of JSON-RPC responses");
         w.encode_entries(
             "inconsistent_responses",
             &m.inconsistent_responses,
@@ -91,11 +87,6 @@ pub fn encode_metrics(w: &mut ic_metrics_encoder::MetricsEncoder<Vec<u8>>) -> st
             "err_http_outcall",
             &m.err_http_outcall,
             "Number of unsuccessful HTTP outcalls",
-        );
-        w.encode_entries(
-            "err_http_response",
-            &m.err_http_response,
-            "Number of HTTP responses with unsuccessful status codes",
         );
         w.encode_entries(
             "err_host_not_allowed",

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,6 +137,8 @@ impl MetricLabels for RpcHost {
 pub struct Metrics {
     pub requests: HashMap<(RpcMethod, RpcHost), u64>,
     pub responses: HashMap<(RpcMethod, RpcHost), u64>,
+    #[serde(rename = "inconsistentResponses")]
+    pub inconsistent_responses: HashMap<(RpcMethod, RpcHost), u64>,
     #[serde(rename = "cyclesCharged")]
     pub cycles_charged: HashMap<(RpcMethod, RpcHost), u128>,
     #[serde(rename = "cyclesWithdrawn")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -143,12 +143,14 @@ pub struct Metrics {
     pub cycles_withdrawn: u128,
     #[serde(rename = "errNoPermission")]
     pub err_no_permission: u64,
-    #[serde(rename = "errHostNotAllowed")]
-    pub err_host_not_allowed: HashMap<RpcHost, u64>,
     #[serde(rename = "errHttpOutcall")]
     pub err_http_outcall: HashMap<(RpcMethod, RpcHost), u64>,
     #[serde(rename = "errHttpResponse")]
     pub err_http_response: HashMap<(RpcMethod, RpcHost), u64>,
+    #[serde(rename = "errHostNotAllowed")]
+    pub err_host_not_allowed: HashMap<RpcHost, u64>,
+    #[serde(rename = "errRateLimit")]
+    pub err_rate_limit: HashMap<RpcHost, u64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, CandidType, Serialize, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -116,18 +116,24 @@ impl<A: MetricLabels, B: MetricLabels> MetricLabels for (A, B) {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, CandidType, Deserialize)]
-pub struct RpcMethod(pub String);
+pub struct MetricRpcMethod(pub String);
 
-impl MetricLabels for RpcMethod {
+impl From<RpcMethod> for MetricRpcMethod {
+    fn from(method: RpcMethod) -> Self {
+        MetricRpcMethod(method.name().to_string())
+    }
+}
+
+impl MetricLabels for MetricRpcMethod {
     fn metric_labels(&self) -> Vec<(&str, &str)> {
         vec![("method", &self.0)]
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, CandidType, Deserialize)]
-pub struct RpcHost(pub String);
+pub struct MetricRpcHost(pub String);
 
-impl MetricLabels for RpcHost {
+impl MetricLabels for MetricRpcHost {
     fn metric_labels(&self) -> Vec<(&str, &str)> {
         vec![("host", &self.0)]
     }
@@ -135,24 +141,47 @@ impl MetricLabels for RpcHost {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, CandidType, Deserialize)]
 pub struct Metrics {
-    pub requests: HashMap<(RpcMethod, RpcHost), u64>,
-    pub responses: HashMap<(RpcMethod, RpcHost), u64>,
+    pub requests: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
+    pub responses: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
     #[serde(rename = "inconsistentResponses")]
-    pub inconsistent_responses: HashMap<(RpcMethod, RpcHost), u64>,
+    pub inconsistent_responses: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
     #[serde(rename = "cyclesCharged")]
-    pub cycles_charged: HashMap<(RpcMethod, RpcHost), u128>,
+    pub cycles_charged: HashMap<(MetricRpcMethod, MetricRpcHost), u128>,
     #[serde(rename = "cyclesWithdrawn")]
     pub cycles_withdrawn: u128,
     #[serde(rename = "errNoPermission")]
     pub err_no_permission: u64,
     #[serde(rename = "errHttpOutcall")]
-    pub err_http_outcall: HashMap<(RpcMethod, RpcHost), u64>,
+    pub err_http_outcall: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
     #[serde(rename = "errHttpResponse")]
-    pub err_http_response: HashMap<(RpcMethod, RpcHost), u64>,
+    pub err_http_response: HashMap<(MetricRpcMethod, MetricRpcHost), u64>,
     #[serde(rename = "errHostNotAllowed")]
-    pub err_host_not_allowed: HashMap<RpcHost, u64>,
+    pub err_host_not_allowed: HashMap<MetricRpcHost, u64>,
     #[serde(rename = "errRateLimit")]
-    pub err_rate_limit: HashMap<RpcHost, u64>,
+    pub err_rate_limit: HashMap<MetricRpcHost, u64>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RpcMethod {
+    EthFeeHistory,
+    EthGetLogs,
+    EthGetBlockByNumber,
+    EthGetTransactionCount,
+    EthGetTransactionReceipt,
+    EthSendRawTransaction,
+}
+
+impl RpcMethod {
+    fn name(self) -> &'static str {
+        match self {
+            RpcMethod::EthFeeHistory => "eth_feeHistory",
+            RpcMethod::EthGetLogs => "eth_getLogs",
+            RpcMethod::EthGetBlockByNumber => "eth_getBlockByNumber",
+            RpcMethod::EthGetTransactionCount => "eth_getTransactionCount",
+            RpcMethod::EthGetTransactionReceipt => "eth_getTransactionReceipt",
+            RpcMethod::EthSendRawTransaction => "eth_sendRawTransaction",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, CandidType, Serialize, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -150,6 +150,12 @@ impl MetricLabels for MetricRpcMethod {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, CandidType, Deserialize)]
 pub struct MetricRpcHost(pub String);
 
+impl<'a> From<&'a str> for MetricRpcHost {
+    fn from(hostname: &str) -> Self {
+        MetricRpcHost(hostname.to_string())
+    }
+}
+
 impl MetricLabels for MetricRpcHost {
     fn metric_labels(&self) -> Vec<(&str, &str)> {
         vec![("host", &self.0)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1185,11 +1185,6 @@ fn candid_rpc_should_recognize_rate_limit() {
                 (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
                 (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
-            responses: hashmap! {
-                // Rate limit is considered a successful HTTP outcall
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
-            },
             err_rate_limit: hashmap! {
                 RpcHost(ANKR_HOSTNAME.to_string()) => 1,
                 RpcHost(CLOUDFLARE_HOSTNAME.to_string()) => 1,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -993,14 +993,14 @@ fn candid_rpc_should_err_when_service_unavailable() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
+                (rpc_method(), PUBLICNODE_ETH_MAINNET_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string()), 503) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string()), 503) => 1,
-                (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string()), 503) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 503.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into(), 503.into()) => 1,
+                (rpc_method(), PUBLICNODE_ETH_MAINNET_HOSTNAME.into(), 503.into()) => 1,
             },
             ..Default::default()
         }
@@ -1036,12 +1036,12 @@ fn candid_rpc_should_recognize_json_error() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(BLOCKPI_ETH_SEPOLIA_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
+                (rpc_method(), BLOCKPI_ETH_SEPOLIA_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(BLOCKPI_ETH_SEPOLIA_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 200.into()) => 1,
+                (rpc_method(), BLOCKPI_ETH_SEPOLIA_HOSTNAME.into(), 200.into()) => 1,
             },
             ..Default::default()
         }
@@ -1100,16 +1100,16 @@ fn candid_rpc_should_return_inconsistent_results() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 200.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into(), 200.into()) => 1,
             },
             inconsistent_responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
             },
             ..Default::default()
         }
@@ -1161,16 +1161,16 @@ fn candid_rpc_should_return_inconsistent_results_with_error() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ALCHEMY_ETH_MAINNET_HOSTNAME.into()) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ALCHEMY_ETH_MAINNET_HOSTNAME.into(), 200.into()) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 400.into()) => 1,
             },
             inconsistent_responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ALCHEMY_ETH_MAINNET_HOSTNAME.into()) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
             },
             ..Default::default()
         }
@@ -1226,16 +1226,16 @@ fn candid_rpc_should_return_inconsistent_results_with_unexpected_status_code() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ALCHEMY_ETH_MAINNET_HOSTNAME.into()) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ALCHEMY_ETH_MAINNET_HOSTNAME.into(), 200.into()) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 200.into()) => 1,
             },
             inconsistent_responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ALCHEMY_ETH_MAINNET_HOSTNAME.into()) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
             },
             ..Default::default()
         }
@@ -1266,12 +1266,12 @@ fn candid_rpc_should_handle_already_known() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 200.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into(), 200.into()) => 1,
             },
             ..Default::default()
         }
@@ -1307,12 +1307,12 @@ fn candid_rpc_should_recognize_rate_limit() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string()), 429) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string()), 429) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 429.into()) => 1,
+                (rpc_method(), CLOUDFLARE_HOSTNAME.into(), 429.into()) => 1,
             },
             ..Default::default()
         }
@@ -1366,10 +1366,10 @@ fn should_restrict_rpc_access() {
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into()) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), ANKR_HOSTNAME.into(), 200.into()) => 1,
             },
             err_no_permission: 1,
             ..Default::default()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1185,6 +1185,10 @@ fn candid_rpc_should_recognize_rate_limit() {
                 (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
                 (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
+            responses: hashmap! {
+                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+            },
             err_rate_limit: hashmap! {
                 RpcHost(ANKR_HOSTNAME.to_string()) => 1,
                 RpcHost(CLOUDFLARE_HOSTNAME.to_string()) => 1,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -998,14 +998,9 @@ fn candid_rpc_should_err_when_service_unavailable() {
                 (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-            },
-            err_http_response: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string()), 503) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string()), 503) => 1,
+                (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string()), 503) => 1,
             },
             ..Default::default()
         }
@@ -1316,12 +1311,8 @@ fn candid_rpc_should_recognize_rate_limit() {
                 (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
-            },
-            err_rate_limit: hashmap! {
-                MetricRpcHost(ANKR_HOSTNAME.to_string()) => 1,
-                MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string()) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string()), 429) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string()), 429) => 1,
             },
             ..Default::default()
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -988,24 +988,24 @@ fn candid_rpc_should_err_when_service_unavailable() {
             }
         ))
     );
-    let rpc_method = || RpcMethod("eth_getTransactionReceipt".to_string());
+    let rpc_method = || RpcMethod::EthGetTransactionReceipt.into();
     assert_eq!(
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
             },
             err_http_response: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(PUBLICNODE_ETH_MAINNET_HOSTNAME.to_string())) => 1,
             },
             ..Default::default()
         }
@@ -1036,17 +1036,17 @@ fn candid_rpc_should_recognize_json_error() {
             message: "Error message".to_string(),
         }))
     );
-    let rpc_method = || RpcMethod("eth_getTransactionReceipt".to_string());
+    let rpc_method = || RpcMethod::EthGetTransactionReceipt.into();
     assert_eq!(
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(BLOCKPI_ETH_SEPOLIA_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(BLOCKPI_ETH_SEPOLIA_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(BLOCKPI_ETH_SEPOLIA_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(BLOCKPI_ETH_SEPOLIA_HOSTNAME.to_string())) => 1,
             },
             ..Default::default()
         }
@@ -1100,17 +1100,17 @@ fn candid_rpc_should_represent_inconsistent_results() {
             )
         ]
     );
-    let rpc_method = || RpcMethod("eth_sendRawTransaction".to_string());
+    let rpc_method = || RpcMethod::EthSendRawTransaction.into();
     assert_eq!(
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
             ..Default::default()
         }
@@ -1136,17 +1136,17 @@ fn candid_rpc_should_handle_already_known() {
         .wait()
         .expect_consistent();
     assert_eq!(result, Ok(SendRawTransactionResult::Ok));
-    let rpc_method = || RpcMethod("eth_sendRawTransaction".to_string());
+    let rpc_method = || RpcMethod::EthSendRawTransaction.into();
     assert_eq!(
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
             ..Default::default()
         }
@@ -1177,21 +1177,21 @@ fn candid_rpc_should_recognize_rate_limit() {
             }
         ))
     );
-    let rpc_method = || RpcMethod("eth_sendRawTransaction".to_string());
+    let rpc_method = || RpcMethod::EthSendRawTransaction.into();
     assert_eq!(
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
             err_rate_limit: hashmap! {
-                RpcHost(ANKR_HOSTNAME.to_string()) => 1,
-                RpcHost(CLOUDFLARE_HOSTNAME.to_string()) => 1,
+                MetricRpcHost(ANKR_HOSTNAME.to_string()) => 1,
+                MetricRpcHost(CLOUDFLARE_HOSTNAME.to_string()) => 1,
             },
             ..Default::default()
         }
@@ -1235,21 +1235,21 @@ fn candid_rpc_should_return_inconsistent_results() {
             ),
         ]
     );
-    let rpc_method = || RpcMethod("eth_sendRawTransaction".to_string());
+    let rpc_method = || RpcMethod::EthSendRawTransaction.into();
     assert_eq!(
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), RpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), RpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
             },
             inconsistent_responses: hashmap! {
-                (rpc_method(), RpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ALCHEMY_ETH_MAINNET_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
             },
             ..Default::default()
         }
@@ -1298,15 +1298,15 @@ fn should_restrict_rpc_access() {
         .wait()
         .expect_consistent();
     assert_eq!(result, Ok(1.into()));
-    let rpc_method = || RpcMethod("eth_getTransactionCount".to_string());
+    let rpc_method = || RpcMethod::EthGetTransactionCount.into();
     assert_eq!(
         setup.get_metrics(),
         Metrics {
             requests: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
             },
             responses: hashmap! {
-                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), MetricRpcHost(ANKR_HOSTNAME.to_string())) => 1,
             },
             err_no_permission: 1,
             ..Default::default()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1185,6 +1185,11 @@ fn candid_rpc_should_recognize_rate_limit() {
                 (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
                 (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
             },
+            responses: hashmap! {
+                // Rate limit is considered a successful HTTP outcall
+                (rpc_method(), RpcHost(ANKR_HOSTNAME.to_string())) => 1,
+                (rpc_method(), RpcHost(CLOUDFLARE_HOSTNAME.to_string())) => 1,
+            },
             err_rate_limit: hashmap! {
                 RpcHost(ANKR_HOSTNAME.to_string()) => 1,
                 RpcHost(CLOUDFLARE_HOSTNAME.to_string()) => 1,


### PR DESCRIPTION
Adds the following metrics:

- `responses` now records the HTTP status codes for JSON-RPC responses.
- `inconsistent_responses` counts the number of `MultiRpcResult::Inconsistent(..)` results for each combination of RPC method and hostname.

Another notable change (not represented in the diff of this PR) is that I adjusted the implementation of `MultiCallResult::all_ok()` in the forked ckETH codebase to return all results in the case of an error. Otherwise, an RPC service could bypass the agreement / consistency logic by returning an error for an otherwise successful RPC request.