### PR TITLE
fix: adjust cycles cost calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.11",
  "once_cell",
  "version_check",
 ]
@@ -1962,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2827,7 +2827,7 @@ name = "ic-crypto-getrandom-for-wasm"
 version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -3509,7 +3509,7 @@ dependencies = [
  "async-trait",
  "ethers-core",
  "ethers-providers",
- "getrandom 0.2.12",
+ "getrandom 0.2.11",
  "hex",
  "ic-cdk",
  "ic-cdk-macros",
@@ -6041,7 +6041,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.11",
 ]
 
 [[package]]
@@ -6122,7 +6122,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.11",
  "libredox",
  "thiserror",
 ]
@@ -6257,7 +6257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
- "getrandom 0.2.12",
+ "getrandom 0.2.11",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -7668,7 +7668,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.11",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "once_cell",
  "version_check",
 ]
@@ -1962,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2827,7 +2827,7 @@ name = "ic-crypto-getrandom-for-wasm"
 version = "0.1.0"
 source = "git+https://github.com/dfinity/ic?rev=release-2023-09-27_23-01#ca5e5052886de781021506814d2c6502e375da48"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -3509,7 +3509,7 @@ dependencies = [
  "async-trait",
  "ethers-core",
  "ethers-providers",
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "hex",
  "ic-cdk",
  "ic-cdk-macros",
@@ -6041,7 +6041,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -6122,7 +6122,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "libredox",
  "thiserror",
 ]
@@ -6257,7 +6257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
 dependencies = [
  "cc",
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -7668,7 +7668,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
  "serde",
 ]
 

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -14,8 +14,8 @@ shared ({ caller = installer }) actor class Main() {
 
         let canisterDetails = [
             // (`canister module`, `debug name`, `nodes in subnet`, `expected cycles for JSON-RPC call`)
-            (EvmRpcCanister, "default", 13, 521_498_000),
-            (EvmRpcFidicuaryCanister, "fiduciary", 28, 1_123_226_461),
+            (EvmRpcCanister, "default", 13, 65_923_200),
+            (EvmRpcFidicuaryCanister, "fiduciary", 28, 141_988_430),
         ];
         for ((canister, name, nodesInSubnet, expectedCycles) in canisterDetails.vals()) {
             Debug.print("Testing " # name # " canister...");

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -13,7 +13,7 @@ pub fn get_json_rpc_cost(
             get_http_request_cost(api, payload_size_bytes, max_response_bytes)
         }
         ResolvedJsonRpcSource::Provider(provider) => {
-            get_candid_rpc_cost(&provider, payload_size_bytes, max_response_bytes)
+            get_candid_rpc_cost(provider, payload_size_bytes, max_response_bytes)
         }
     }
 }

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -25,9 +25,10 @@ pub fn get_candid_rpc_cost(
     payload_size_bytes: u64,
     effective_response_size_estimate: u64,
 ) -> u128 {
-    let base_cost = 400_000_000u128 + 100_000u128 * (2 * effective_response_size_estimate as u128);
-    let subnet_size = UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow()) as u128;
-    let http_cost = base_cost * subnet_size / NODES_IN_DEFAULT_SUBNET as u128;
+    let base_cost = HTTP_OUTCALL_REQUEST_COST
+        + HTTP_OUTCALL_BYTE_RECEIVED_COST * (2 * effective_response_size_estimate as u128);
+    let nodes_in_subnet = UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow()) as u128;
+    let http_cost = base_cost * nodes_in_subnet / NODES_IN_DEFAULT_SUBNET as u128;
     let provider_cost = get_provider_cost(provider, payload_size_bytes);
     http_cost + provider_cost
 }

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -155,15 +155,15 @@ fn test_candid_rpc_cost() {
     let provider = PROVIDERS.with(|providers| providers.borrow().get(&provider_id).unwrap());
 
     // Default subnet
-    assert_eq!(get_candid_rpc_cost(&provider, 0, 0), 437524987);
-    assert_eq!(get_candid_rpc_cost(&provider, 123, 123), 463969987);
-    assert_eq!(get_candid_rpc_cost(&provider, 123, 4567890), 457240669987);
-    assert_eq!(get_candid_rpc_cost(&provider, 890, 4567890), 457328874987);
+    assert_eq!(get_candid_rpc_cost(&provider, 0, 0), 54767387);
+    assert_eq!(get_candid_rpc_cost(&provider, 123, 123), 59170787);
+    assert_eq!(get_candid_rpc_cost(&provider, 123, 4567890), 47563947587);
+    assert_eq!(get_candid_rpc_cost(&provider, 890, 4567890), 47583429387);
 
     // Fiduciary subnet
     UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow_mut() = NODES_IN_FIDUCIARY_SUBNET);
-    assert_eq!(get_candid_rpc_cost(&provider, 0, 0), 942361510);
-    assert_eq!(get_candid_rpc_cost(&provider, 123, 123), 999319972);
-    assert_eq!(get_candid_rpc_cost(&provider, 123, 4567890), 984826058433);
-    assert_eq!(get_candid_rpc_cost(&provider, 890, 4567890), 985016038433);
+    assert_eq!(get_candid_rpc_cost(&provider, 0, 0), 117960525);
+    assert_eq!(get_candid_rpc_cost(&provider, 123, 123), 127444772);
+    assert_eq!(get_candid_rpc_cost(&provider, 123, 4567890), 102445425572);
+    assert_eq!(get_candid_rpc_cost(&provider, 890, 4567890), 102487386372);
 }

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -155,15 +155,15 @@ fn test_candid_rpc_cost() {
     let provider = PROVIDERS.with(|providers| providers.borrow().get(&provider_id).unwrap());
 
     // Default subnet
-    assert_eq!(get_candid_rpc_cost(&provider, 0, 0), 413758987);
-    assert_eq!(get_candid_rpc_cost(&provider, 123, 123), 440203987);
-    assert_eq!(get_candid_rpc_cost(&provider, 123, 4567890), 457216903987);
-    assert_eq!(get_candid_rpc_cost(&provider, 890, 4567890), 457305108987);
+    assert_eq!(get_candid_rpc_cost(&provider, 0, 0), 437524987);
+    assert_eq!(get_candid_rpc_cost(&provider, 123, 123), 463969987);
+    assert_eq!(get_candid_rpc_cost(&provider, 123, 4567890), 457240669987);
+    assert_eq!(get_candid_rpc_cost(&provider, 890, 4567890), 457328874987);
 
     // Fiduciary subnet
     UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow_mut() = NODES_IN_FIDUCIARY_SUBNET);
-    assert_eq!(get_candid_rpc_cost(&provider, 0, 0), 891173202);
-    assert_eq!(get_candid_rpc_cost(&provider, 123, 123), 948131664);
-    assert_eq!(get_candid_rpc_cost(&provider, 123, 4567890), 984774870125);
-    assert_eq!(get_candid_rpc_cost(&provider, 890, 4567890), 984964850125);
+    assert_eq!(get_candid_rpc_cost(&provider, 0, 0), 942361510);
+    assert_eq!(get_candid_rpc_cost(&provider, 123, 123), 999319972);
+    assert_eq!(get_candid_rpc_cost(&provider, 123, 4567890), 984826058433);
+    assert_eq!(get_candid_rpc_cost(&provider, 890, 4567890), 985016038433);
 }

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -25,9 +25,9 @@ pub fn get_candid_rpc_cost(
     payload_size_bytes: u64,
     effective_response_size_estimate: u64,
 ) -> u128 {
+    let nodes_in_subnet = UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow()) as u128;
     let base_cost = HTTP_OUTCALL_REQUEST_COST
         + HTTP_OUTCALL_BYTE_RECEIVED_COST * (2 * effective_response_size_estimate as u128);
-    let nodes_in_subnet = UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow()) as u128;
     let http_cost = base_cost * nodes_in_subnet / NODES_IN_DEFAULT_SUBNET as u128;
     let provider_cost = get_provider_cost(provider, payload_size_bytes);
     http_cost + provider_cost

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -12,25 +12,11 @@ pub fn get_json_rpc_cost(
         ResolvedJsonRpcSource::Api(api) => {
             get_http_request_cost(api, payload_size_bytes, max_response_bytes)
         }
-        ResolvedJsonRpcSource::Provider(p) => {
-            get_http_request_cost(&p.api(), payload_size_bytes, max_response_bytes)
-                + get_provider_cost(p, payload_size_bytes)
+        ResolvedJsonRpcSource::Provider(provider) => {
+            get_http_request_cost(&provider.api(), payload_size_bytes, max_response_bytes)
+                + get_provider_cost(provider, payload_size_bytes)
         }
     }
-}
-
-/// Returns the cycles cost of a Candid-RPC request.
-pub fn get_candid_rpc_cost(
-    provider: &Provider,
-    payload_size_bytes: u64,
-    effective_response_size_estimate: u64,
-) -> u128 {
-    let nodes_in_subnet = UNSTABLE_SUBNET_SIZE.with(|n| *n.borrow()) as u128;
-    let base_cost = HTTP_OUTCALL_REQUEST_COST
-        + HTTP_OUTCALL_BYTE_RECEIVED_COST * (2 * effective_response_size_estimate as u128);
-    let http_cost = base_cost * nodes_in_subnet / NODES_IN_DEFAULT_SUBNET as u128;
-    let provider_cost = get_provider_cost(provider, payload_size_bytes);
-    http_cost + provider_cost
 }
 
 /// Calculates the baseline cost of sending a JSON-RPC request using HTTP outcalls.

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -34,8 +34,8 @@ impl RpcTransport for CanisterTransport {
         effective_response_size_estimate: u64,
     ) -> RpcResult<HttpResponse> {
         let provider = resolve_provider(service)?;
-        let cycles_cost = get_candid_rpc_cost(
-            &provider,
+        let cycles_cost = get_http_request_cost(
+            &provider.api(),
             request
                 .body
                 .as_ref()

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -34,8 +34,8 @@ impl RpcTransport for CanisterTransport {
         effective_response_size_estimate: u64,
     ) -> RpcResult<HttpResponse> {
         let provider = resolve_provider(service)?;
-        let cycles_cost = get_http_request_cost(
-            &provider.api(),
+        let cycles_cost = get_candid_rpc_cost(
+            &provider,
             request
                 .body
                 .as_ref()

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,8 +3,8 @@ use cketh_common::eth_rpc_client::providers::{EthMainnetService, EthSepoliaServi
 pub const INGRESS_OVERHEAD_BYTES: u128 = 100;
 pub const INGRESS_MESSAGE_RECEIVED_COST: u128 = 1_200_000;
 pub const INGRESS_MESSAGE_BYTE_RECEIVED_COST: u128 = 2_000;
-pub const HTTP_OUTCALL_REQUEST_COST: u128 = 400_000_000;
-pub const HTTP_OUTCALL_BYTE_RECEIVED_COST: u128 = 100_000;
+pub const HTTP_OUTCALL_REQUEST_COST: u128 = 49_140_000;
+pub const HTTP_OUTCALL_BYTE_RECEIVED_COST: u128 = 10_400;
 
 // Minimum number of bytes charged for a URL; improves consistency of costs between providers
 pub const RPC_URL_MIN_COST_BYTES: u32 = 256;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,6 +6,9 @@ pub const INGRESS_MESSAGE_BYTE_RECEIVED_COST: u128 = 2_000;
 pub const HTTP_OUTCALL_REQUEST_COST: u128 = 400_000_000;
 pub const HTTP_OUTCALL_BYTE_RECEIVED_COST: u128 = 100_000;
 
+// Minimum number of bytes charged for a URL; improves consistency of costs between providers
+pub const RPC_URL_MIN_COST_BYTES: u32 = 256;
+
 pub const MINIMUM_WITHDRAWAL_CYCLES: u128 = 1_000_000_000;
 
 pub const STRING_STORABLE_MAX_SIZE: u32 = 100;


### PR DESCRIPTION
Removes `get_candid_rpc_cost()` (cost calculation from ckETH) in favor of the more precise `get_http_request_cost()`. This PR also updates the HTTP outcall prices to reflect the latest values [from the developer docs](https://internetcomputer.org/docs/current/developer-docs/gas-cost).

Closes #129.