### PR TITLE
chore: point `cketh-common` to official `dfinity/ic` repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "candid",
  "serde",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "askama",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2861,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "sha3",
 ]
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3336,7 +3336,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "bincode",
  "candid",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "cvt",
  "hex",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "async-trait",
  "candid",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "async-trait",
  "candid",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "base32",
  "candid",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-cketh-common = { git = "https://github.com/rvanasa/ic", rev = "13af7fa681e3055adae4e83d172204bd3c8188b6", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/dfinity/ic", rev = "13af7fa681e3055adae4e83d172204bd3c8188b6", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"


### PR DESCRIPTION
Replaces a personal GitHub fork with the [`evm-rpc-canister`](https://github.com/dfinity/ic/tree/evm-rpc-canister) branch mirrored onto the `dfinity/ic` GitHub repository.