### PR TITLE
feat!: add `RpcConfig` arg to Candid-RPC methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "candid",
  "serde",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "askama",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2861,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "sha3",
 ]
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3336,7 +3336,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "bincode",
  "candid",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "cvt",
  "hex",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "async-trait",
  "candid",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "async-trait",
  "candid",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "base32",
  "candid",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
+source = "git+https://github.com/rvanasa/ic?rev=6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e#6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "base32",
  "byte-unit",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2275,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "candid",
  "serde",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "ic-cketh-minter"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "askama",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "k256",
  "lazy_static",
@@ -2861,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "ic-crypto-internal-sha2 0.9.0",
 ]
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha3"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "sha3",
 ]
@@ -3249,7 +3249,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
@@ -3336,7 +3336,7 @@ dependencies = [
 [[package]]
 name = "ic-ic00-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "candid",
  "ic-base-types 0.9.0",
@@ -3626,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "bincode",
  "candid",
@@ -3948,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "hex",
  "ic-crypto-sha2 0.9.0",
@@ -4090,7 +4090,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "cvt",
  "hex",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "ic-utils-ensure"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 
 [[package]]
 name = "ic-utils-lru-cache"
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "async-trait",
  "candid",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client-cdk"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "async-trait",
  "candid",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.4"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "base32",
  "candid",
@@ -5168,7 +5168,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=13af7fa681e3055adae4e83d172204bd3c8188b6#13af7fa681e3055adae4e83d172204bd3c8188b6"
+source = "git+https://github.com/rvanasa/ic?rev=4cf8effe8c2f60f889955302a79a800f898dfb29#4cf8effe8c2f60f889955302a79a800f898dfb29"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-cketh-common = { git = "https://github.com/rvanasa/ic", rev = "4cf8effe8c2f60f889955302a79a800f898dfb29", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/rvanasa/ic", rev = "6a8e2eb86e4e48ad8d8a4b49d6477b7112aae12e", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ic-stable-structures = { workspace = true }
 ic-certified-map = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
-cketh-common = { git = "https://github.com/dfinity/ic", rev = "13af7fa681e3055adae4e83d172204bd3c8188b6", package = "ic-cketh-minter" }
+cketh-common = { git = "https://github.com/rvanasa/ic", rev = "4cf8effe8c2f60f889955302a79a800f898dfb29", package = "ic-cketh-minter" }
 maplit = "1.0"
 num = "0.4"
 num-traits = "0.2"

--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -172,6 +172,7 @@ type SendRawTransactionResult = variant {
 };
 type RequestResult = variant { Ok : text; Err : RpcError };
 type RequestCostResult = variant { Ok : nat; Err : RpcError };
+type RpcConfig = record { responseSizeEstimate : opt nat64 };
 type RpcError = variant {
   JsonRpcError : JsonRpcError;
   ProviderError : ProviderError;
@@ -226,14 +227,14 @@ type ValidationError = variant {
 service : (InitArgs) -> {
   authorize : (principal, Auth) -> ();
   deauthorize : (principal, Auth) -> ();
-  eth_feeHistory : (RpcSource, FeeHistoryArgs) -> (MultiFeeHistoryResult);
-  eth_getBlockByNumber : (RpcSource, BlockTag) -> (MultiGetBlockByNumberResult);
-  eth_getLogs : (RpcSource, GetLogsArgs) -> (MultiGetLogsResult);
-  eth_getTransactionCount : (RpcSource, GetTransactionCountArgs) -> (
+  eth_feeHistory : (RpcSource, opt RpcConfig, FeeHistoryArgs) -> (MultiFeeHistoryResult);
+  eth_getBlockByNumber : (RpcSource, opt RpcConfig, BlockTag) -> (MultiGetBlockByNumberResult);
+  eth_getLogs : (RpcSource, opt RpcConfig, GetLogsArgs) -> (MultiGetLogsResult);
+  eth_getTransactionCount : (RpcSource, opt RpcConfig, GetTransactionCountArgs) -> (
     MultiGetTransactionCountResult
   );
-  eth_getTransactionReceipt : (RpcSource, text) -> (MultiGetTransactionReceiptResult);
-  eth_sendRawTransaction : (RpcSource, text) -> (MultiSendRawTransactionResult);
+  eth_getTransactionReceipt : (RpcSource, opt RpcConfig, text) -> (MultiGetTransactionReceiptResult);
+  eth_sendRawTransaction : (RpcSource, opt RpcConfig, text) -> (MultiSendRawTransactionResult);
   getAccumulatedCycleCount : (nat64) -> (nat) query;
   getAuthorized : (Auth) -> (vec principal) query;
   getMetrics : () -> (Metrics) query;

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -122,7 +122,7 @@ shared ({ caller = installer }) actor class Main() {
             let candidRpcCycles = 1_000_000_000_000;
             let ethMainnetSource = #EthMainnet(?[#Alchemy, #Ankr, #Cloudflare, #BlockPi, #PublicNode]);
 
-            switch (await canister.eth_getBlockByNumber(ethMainnetSource, #Latest)) {
+            switch (await canister.eth_getBlockByNumber(ethMainnetSource, null, #Latest)) {
                 case (#Consistent(#Err(#ProviderError(#TooFewCycles _)))) {};
                 case result {
                     Debug.trap("received unexpected result: " # debug_show result);
@@ -134,6 +134,7 @@ shared ({ caller = installer }) actor class Main() {
                 "eth_getLogs",
                 await canister.eth_getLogs(
                     ethMainnetSource,
+                    null,
                     {
                         addresses = ["0xdAC17F958D2ee523a2206206994597C13D831ec7"];
                         fromBlock = null;
@@ -145,18 +146,19 @@ shared ({ caller = installer }) actor class Main() {
             Cycles.add(candidRpcCycles);
             assertOk(
                 "eth_getBlockByNumber",
-                await canister.eth_getBlockByNumber(ethMainnetSource, #Latest),
+                await canister.eth_getBlockByNumber(ethMainnetSource, null, #Latest),
             );
             Cycles.add(candidRpcCycles);
             assertOk(
                 "eth_getTransactionReceipt",
-                await canister.eth_getTransactionReceipt(ethMainnetSource, "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f"),
+                await canister.eth_getTransactionReceipt(ethMainnetSource, null, "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f"),
             );
             Cycles.add(candidRpcCycles);
             assertOk(
                 "eth_getTransactionCount",
                 await canister.eth_getTransactionCount(
                     ethMainnetSource,
+                    null,
                     {
                         address = "0x1789F79e95324A47c5Fd6693071188e82E9a3558";
                         block = #Latest;
@@ -168,6 +170,7 @@ shared ({ caller = installer }) actor class Main() {
                 "eth_feeHistory",
                 await canister.eth_feeHistory(
                     ethMainnetSource,
+                    null,
                     {
                         blockCount = 3;
                         newestBlock = #Latest;
@@ -180,6 +183,7 @@ shared ({ caller = installer }) actor class Main() {
                 "eth_sendRawTransaction",
                 await canister.eth_sendRawTransaction(
                     ethMainnetSource,
+                    null,
                     "0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83",
                 ),
             );

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -45,11 +45,11 @@ shared ({ caller = installer }) actor class Main() {
             let cycles = switch cyclesResult {
                 case (#Ok cycles) { cycles };
                 case (#Err err) {
-                    Debug.trap("unexpected error for `request_cost`: " # (debug_show err));
+                    Debug.trap("Unexpected error for `request_cost`: " # (debug_show err));
                 };
             };
             if (cycles != expectedCycles) {
-                Debug.trap("unexpected number of cycles for " # name # " canister: " # debug_show cycles # " (expected " # debug_show expectedCycles # ")");
+                Debug.trap("Unexpected number of cycles for " # name # " canister: " # debug_show cycles # " (expected " # debug_show expectedCycles # ")");
             };
 
             // `request()` without cycles
@@ -98,7 +98,7 @@ shared ({ caller = installer }) actor class Main() {
                 switch result {
                     case (#Consistent(#Ok _)) {};
                     case (#Consistent(#Err err)) {
-                        Debug.trap("received error for " # method # ": " # debug_show err);
+                        Debug.trap("Received error for " # method # ": " # debug_show err);
                     };
                     case (#Inconsistent(results)) {
                         for ((service, result) in results.vals()) {
@@ -111,7 +111,7 @@ shared ({ caller = installer }) actor class Main() {
                                             return;
                                         };
                                     };
-                                    Debug.trap("received error in inconsistent results for " # debug_show service # " " # method # ": " # debug_show err);
+                                    Debug.trap("Received error in inconsistent results for " # debug_show service # " " # method # ": " # debug_show err);
                                 };
                             };
                         };
@@ -125,7 +125,7 @@ shared ({ caller = installer }) actor class Main() {
             switch (await canister.eth_getBlockByNumber(ethMainnetSource, null, #Latest)) {
                 case (#Consistent(#Err(#ProviderError(#TooFewCycles _)))) {};
                 case result {
-                    Debug.trap("received unexpected result: " # debug_show result);
+                    Debug.trap("Received unexpected result: " # debug_show result);
                 };
             };
 

--- a/src/candid_rpc.rs
+++ b/src/candid_rpc.rs
@@ -82,7 +82,7 @@ fn get_rpc_client(
             EthereumNetwork::Mainnet,
             Some(
                 check_services(services)?
-                    .unwrap_or_else(|| DEFAULT_ETHEREUM_SERVICES.to_vec())
+                    .unwrap_or_else(|| DEFAULT_ETH_MAINNET_SERVICES.to_vec())
                     .into_iter()
                     .map(RpcService::EthMainnet)
                     .collect(),
@@ -93,7 +93,7 @@ fn get_rpc_client(
             EthereumNetwork::Sepolia,
             Some(
                 check_services(services)?
-                    .unwrap_or_else(|| DEFAULT_SEPOLIA_SERVICES.to_vec())
+                    .unwrap_or_else(|| DEFAULT_ETH_SEPOLIA_SERVICES.to_vec())
                     .into_iter()
                     .map(RpcService::EthSepolia)
                     .collect(),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,12 +23,12 @@ pub const NODES_IN_FIDUCIARY_SUBNET: u32 = 28;
 pub const DEFAULT_OPEN_RPC_ACCESS: bool = true;
 
 // Providers used by default (when passing `null` with `CandidRpcSource`)
-pub const DEFAULT_ETHEREUM_SERVICES: &[EthMainnetService] = &[
+pub const DEFAULT_ETH_MAINNET_SERVICES: &[EthMainnetService] = &[
     EthMainnetService::Ankr,
     EthMainnetService::Cloudflare,
     EthMainnetService::PublicNode,
 ];
-pub const DEFAULT_SEPOLIA_SERVICES: &[EthSepoliaService] = &[
+pub const DEFAULT_ETH_SEPOLIA_SERVICES: &[EthSepoliaService] = &[
     EthSepoliaService::Ankr,
     EthSepoliaService::BlockPi,
     EthSepoliaService::PublicNode,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use cketh_common::eth_rpc::{
 };
 
 use cketh_common::eth_rpc_client::providers::RpcService;
+use cketh_common::eth_rpc_client::RpcConfig;
 use cketh_common::logs::INFO;
 use ic_canister_log::log;
 use ic_canisters_http_types::{
@@ -19,9 +20,10 @@ use evm_rpc::*;
 #[candid_method(rename = "eth_getLogs")]
 pub async fn eth_get_logs(
     source: RpcSource,
+    config: Option<RpcConfig>,
     args: candid_types::GetLogsArgs,
 ) -> MultiRpcResult<Vec<LogEntry>> {
-    match CandidRpcClient::from_source(source) {
+    match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_get_logs(args).await,
         Err(err) => Err(err).into(),
     }
@@ -31,9 +33,10 @@ pub async fn eth_get_logs(
 #[candid_method(rename = "eth_getBlockByNumber")]
 pub async fn eth_get_block_by_number(
     source: RpcSource,
+    config: Option<RpcConfig>,
     block: candid_types::BlockTag,
 ) -> MultiRpcResult<Block> {
-    match CandidRpcClient::from_source(source) {
+    match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_get_block_by_number(block).await,
         Err(err) => Err(err).into(),
     }
@@ -43,9 +46,10 @@ pub async fn eth_get_block_by_number(
 #[candid_method(rename = "eth_getTransactionReceipt")]
 pub async fn eth_get_transaction_receipt(
     source: RpcSource,
+    config: Option<RpcConfig>,
     hash: String,
 ) -> MultiRpcResult<Option<candid_types::TransactionReceipt>> {
-    match CandidRpcClient::from_source(source) {
+    match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_get_transaction_receipt(hash).await,
         Err(err) => Err(err).into(),
     }
@@ -55,9 +59,10 @@ pub async fn eth_get_transaction_receipt(
 #[candid_method(rename = "eth_getTransactionCount")]
 pub async fn eth_get_transaction_count(
     source: RpcSource,
+    config: Option<RpcConfig>,
     args: candid_types::GetTransactionCountArgs,
 ) -> MultiRpcResult<candid::Nat> {
-    match CandidRpcClient::from_source(source) {
+    match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_get_transaction_count(args).await,
         Err(err) => Err(err).into(),
     }
@@ -67,9 +72,10 @@ pub async fn eth_get_transaction_count(
 #[candid_method(rename = "eth_feeHistory")]
 pub async fn eth_fee_history(
     source: RpcSource,
+    config: Option<RpcConfig>,
     args: candid_types::FeeHistoryArgs,
 ) -> MultiRpcResult<Option<FeeHistory>> {
-    match CandidRpcClient::from_source(source) {
+    match CandidRpcClient::new(source, config) {
         Ok(source) => source.eth_fee_history(args).await,
         Err(err) => Err(err).into(),
     }
@@ -79,9 +85,10 @@ pub async fn eth_fee_history(
 #[candid_method(rename = "eth_sendRawTransaction")]
 pub async fn eth_send_raw_transaction(
     source: RpcSource,
+    config: Option<RpcConfig>,
     raw_signed_transaction_hex: String,
 ) -> MultiRpcResult<SendRawTransactionResult> {
-    match CandidRpcClient::from_source(source) {
+    match CandidRpcClient::new(source, config) {
         Ok(source) => {
             source
                 .eth_send_raw_transaction(raw_signed_transaction_hex)

--- a/tests/mock.rs
+++ b/tests/mock.rs
@@ -32,6 +32,7 @@ impl MockOutcallBuilder {
             url: None,
             request_headers: None,
             request_body: None,
+            max_response_bytes: None,
             response: HttpResponse {
                 status: status.into(),
                 headers: vec![],
@@ -68,6 +69,11 @@ impl MockOutcallBuilder {
         self
     }
 
+    pub fn with_max_response_bytes(mut self, max_response_bytes: u64) -> Self {
+        self.0.max_response_bytes = Some(max_response_bytes);
+        self
+    }
+
     pub fn with_response_header(mut self, name: String, value: String) -> Self {
         self.0.response.headers.push(HttpHeader { name, value });
         self
@@ -90,6 +96,7 @@ pub struct MockOutcall {
     pub url: Option<String>,
     pub request_headers: Option<Vec<HttpHeader>>,
     pub request_body: Option<Vec<u8>>,
+    pub max_response_bytes: Option<u64>,
     pub response: HttpResponse,
 }
 
@@ -110,6 +117,9 @@ impl MockOutcall {
         if let Some(ref body) = self.request_body {
             assert_eq!(body, &request.body.as_deref().unwrap_or_default());
         }
+        if let Some(max_response_bytes) = self.max_response_bytes {
+            assert_eq!(Some(max_response_bytes), request.max_response_bytes);
+        }
     }
 }
 
@@ -120,6 +130,7 @@ impl From<HttpResponse> for MockOutcall {
             url: None,
             request_headers: None,
             request_body: None,
+            max_response_bytes: None,
             response,
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1663,7 +1663,7 @@ fn should_restrict_rpc_access() {
 #[test]
 fn should_use_custom_response_size_estimate() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
-    let max_response_bytes = 12345;
+    let max_response_bytes = 1234;
     let expected_response = r#"{"id":0,"jsonrpc":"2.0","result":[{"address":"0xdac17f958d2ee523a2206206994597c13d831ec7","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x000000000000000000000000a9d1e08c7793af67e9d92fe308d5697fb81d3e43","0x00000000000000000000000078cccfb3d517cd4ed6d045e263e134712288ace2"],"data":"0x000000000000000000000000000000000000000000000000000000003b9c6433","blockNumber":"0x11dc77e","transactionHash":"0xf3ed91a03ddf964281ac7a24351573efd535b80fc460a5c2ad2b9d23153ec678","transactionIndex":"0x65","blockHash":"0xd5c72ad752b2f0144a878594faf8bd9f570f2f72af8e7f0940d3545a6388f629","logIndex":"0xe8","removed":false}]}"#;
     let response = setup
         .eth_get_logs(
@@ -1680,7 +1680,7 @@ fn should_use_custom_response_size_estimate() {
         )
         .mock_http_once(
             MockOutcallBuilder::new(200, expected_response)
-                .with_max_response_bytes(max_response_bytes + 2048),
+                .with_max_response_bytes(max_response_bytes),
         )
         .wait()
         .expect_consistent();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1670,7 +1670,6 @@ fn should_use_custom_response_size_estimate() {
             RpcSource::EthMainnet(Some(vec![EthMainnetService::Cloudflare])),
             Some(RpcConfig {
                 response_size_estimate: Some(max_response_bytes),
-                ..Default::default()
             }),
             candid_types::GetLogsArgs {
                 addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string()],

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -972,7 +972,8 @@ fn eth_get_logs_should_succeed() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let response = setup
         .eth_get_logs(
-            RpcSource::EthMainnet(None),None,
+            RpcSource::EthMainnet(None),
+            None,
             candid_types::GetLogsArgs {
                 addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string()],
                 from_block: None,
@@ -1025,7 +1026,8 @@ fn eth_get_block_by_number_should_succeed() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let response = setup
         .eth_get_block_by_number(
-            RpcSource::EthMainnet(None),None,
+            RpcSource::EthMainnet(None),
+            None,
             candid_types::BlockTag::Latest,
         )
         .mock_http(MockOutcallBuilder::new(200, r#"{"jsonrpc":"2.0","result":{"baseFeePerGas":"0xd7232aa34","difficulty":"0x0","extraData":"0x546974616e2028746974616e6275696c6465722e78797a29","gasLimit":"0x1c9c380","gasUsed":"0xa768c4","hash":"0xc3674be7b9d95580d7f23c03d32e946f2b453679ee6505e3a778f003c5a3cfae","logsBloom":"0x3e6b8420e1a13038902c24d6c2a9720a7ad4860cdc870cd5c0490011e43631134f608935bd83171247407da2c15d85014f9984608c03684c74aad48b20bc24022134cdca5f2e9d2dee3b502a8ccd39eff8040b1d96601c460e119c408c620b44fa14053013220847045556ea70484e67ec012c322830cf56ef75e09bd0db28a00f238adfa587c9f80d7e30d3aba2863e63a5cad78954555966b1055a4936643366a0bb0b1bac68d0e6267fc5bf8304d404b0c69041125219aa70562e6a5a6362331a414a96d0716990a10161b87dd9568046a742d4280014975e232b6001a0360970e569d54404b27807d7a44c949ac507879d9d41ec8842122da6772101bc8b","miner":"0x388c818ca8b9251b393131c08a736a67ccb19297","mixHash":"0x516a58424d4883a3614da00a9c6f18cd5cd54335a08388229a993a8ecf05042f","nonce":"0x0000000000000000","number":"0x11db01d","parentHash":"0x43325027f6adf9befb223f8ae80db057daddcd7b48e41f60cd94bfa8877181ae","receiptsRoot":"0x66934c3fd9c547036fe0e56ad01bc43c84b170be7c4030a86805ddcdab149929","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0xcd35","stateRoot":"0x13552447dd62f11ad885f21a583c4fa34144efe923c7e35fb018d6710f06b2b6","timestamp":"0x656f96f3","totalDifficulty":"0xc70d815d562d3cfa955","withdrawalsRoot":"0xecae44b2c53871003c5cc75285995764034c9b5978a904229d36c1280b141d48"},"id":0}"#))
@@ -1065,7 +1067,8 @@ fn eth_get_transaction_receipt_should_succeed() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let response = setup
         .eth_get_transaction_receipt(
-            RpcSource::EthMainnet(None),None,
+            RpcSource::EthMainnet(None),
+            None,
             "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f",
         )
         .mock_http(MockOutcallBuilder::new(200, r#"{"jsonrpc":"2.0","id":2,"result":{"blockHash":"0x5115c07eb1f20a9d6410db0916ed3df626cfdab161d3904f45c8c8b65c90d0be","blockNumber":"0x11a85ab","contractAddress":null,"cumulativeGasUsed":"0xf02aed","effectiveGasPrice":"0x63c00ee76","from":"0x0aa8ebb6ad5a8e499e550ae2c461197624c6e667","gasUsed":"0x7d89","logs":[],"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","status":"0x1","to":"0x356cfd6e6d0000400000003900b415f80669009e","transactionHash":"0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f","transactionIndex":"0xd9","type":"0x2"}}"#))
@@ -1119,7 +1122,8 @@ fn eth_fee_history_should_succeed() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let response = setup
         .eth_fee_history(
-            RpcSource::EthMainnet(None),None,
+            RpcSource::EthMainnet(None),
+            None,
             candid_types::FeeHistoryArgs {
                 block_count: 3,
                 newest_block: candid_types::BlockTag::Latest,
@@ -1152,7 +1156,8 @@ fn eth_send_raw_transaction_should_succeed() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let response = setup
         .eth_send_raw_transaction(
-            RpcSource::EthMainnet(None),None,
+            RpcSource::EthMainnet(None),
+            None,
             "0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83",
         )
         .mock_http(MockOutcallBuilder::new(
@@ -1170,7 +1175,8 @@ fn candid_rpc_should_allow_unexpected_response_fields() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let response = setup
         .eth_get_transaction_receipt(
-            RpcSource::EthMainnet(None),None,
+            RpcSource::EthMainnet(None),
+            None,
             "0xdd5d4b18923d7aae953c7996d791118102e889bea37b48a651157a4890e4746f",
         )
         .mock_http(MockOutcallBuilder::new(200, r#"{"jsonrpc":"2.0","id":0,"result":{"unexpectedKey":"unexpectedValue","blockHash":"0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35","blockNumber":"0x5bad55","contractAddress":null,"cumulativeGasUsed":"0xb90b0","effectiveGasPrice":"0x746a528800","from":"0x398137383b3d25c92898c656696e41950e47316b","gasUsed":"0x1383f","logs":[],"logsBloom":"0x0","status":"0x1","to":"0x06012c8cf97bead5deae237070f9587f8e7a266d","transactionHash":"0xbb3a336e3f823ec18197f1e13ee875700f08f03e2cab75f0d0b118dabb44cba0","transactionIndex":"0x11","type":"0x0"}}"#))
@@ -1337,7 +1343,8 @@ fn candid_rpc_should_return_inconsistent_results() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let results = setup
         .eth_send_raw_transaction(
-            RpcSource::EthMainnet(Some(vec![EthMainnetService::Ankr, EthMainnetService::Cloudflare])),None,
+            RpcSource::EthMainnet(Some(vec![EthMainnetService::Ankr, EthMainnetService::Cloudflare])),
+            None,
             "0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83",
         )
         .mock_http_once(MockOutcallBuilder::new(
@@ -1514,7 +1521,8 @@ fn candid_rpc_should_handle_already_known() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let result = setup
         .eth_send_raw_transaction(
-            RpcSource::EthMainnet(Some(vec![EthMainnetService::Ankr, EthMainnetService::Cloudflare])),None,
+            RpcSource::EthMainnet(Some(vec![EthMainnetService::Ankr, EthMainnetService::Cloudflare])),
+            None,
             "0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83",
         )
         .mock_http_once(MockOutcallBuilder::new(
@@ -1550,7 +1558,8 @@ fn candid_rpc_should_recognize_rate_limit() {
     let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
     let result = setup
         .eth_send_raw_transaction(
-            RpcSource::EthMainnet(Some(vec![EthMainnetService::Ankr, EthMainnetService::Cloudflare])),None,
+            RpcSource::EthMainnet(Some(vec![EthMainnetService::Ankr, EthMainnetService::Cloudflare])),
+            None,
             "0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83",
         )
         .mock_http(MockOutcallBuilder::new(
@@ -1644,4 +1653,43 @@ fn should_restrict_rpc_access() {
             ..Default::default()
         }
     );
+}
+
+#[test]
+fn should_use_custom_response_size_estimate() {
+    let setup = EvmRpcSetup::new().authorize_caller(Auth::FreeRpc);
+    let source = RpcSource::EthMainnet(None);
+    let args = candid_types::GetLogsArgs {
+        addresses: vec!["0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string()],
+        from_block: None,
+        to_block: None,
+        topics: None,
+    };
+    let expected_response = r#"{"id":0,"jsonrpc":"2.0","result":[{"address":"0xdac17f958d2ee523a2206206994597c13d831ec7","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x000000000000000000000000a9d1e08c7793af67e9d92fe308d5697fb81d3e43","0x00000000000000000000000078cccfb3d517cd4ed6d045e263e134712288ace2"],"data":"0x000000000000000000000000000000000000000000000000000000003b9c6433","blockNumber":"0x11dc77e","transactionHash":"0xf3ed91a03ddf964281ac7a24351573efd535b80fc460a5c2ad2b9d23153ec678","transactionIndex":"0x65","blockHash":"0xd5c72ad752b2f0144a878594faf8bd9f570f2f72af8e7f0940d3545a6388f629","logIndex":"0xe8","removed":false}]}"#;
+    let response_10kb = setup
+        .eth_get_logs(
+            source.clone(),
+            Some(RpcConfig {
+                response_size_estimate: Some(100),
+                ..Default::default()
+            }),
+            args.clone(),
+        )
+        .mock_http_n_times(MockOutcallBuilder::new(200, expected_response), 3)
+        .wait()
+        .expect_consistent();
+    assert_matches!(response_10kb, Ok(_));
+    let response_1000_bytes = setup
+        .eth_get_logs(
+            source,
+            Some(RpcConfig {
+                response_size_estimate: Some(10_000),
+                ..Default::default()
+            }),
+            args,
+        )
+        .mock_http_n_times(MockOutcallBuilder::new(200, expected_response), 1)
+        .wait()
+        .expect_consistent();
+    assert_matches!(response_1000_bytes, Ok(_));
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -516,6 +516,11 @@ fn mock_request_should_succeed_with_request_body() {
 }
 
 #[test]
+fn mock_request_should_succeed_with_max_response_bytes() {
+    mock_request(|builder| builder.with_max_response_bytes(MOCK_REQUEST_RESPONSE_BYTES))
+}
+
+#[test]
 fn mock_request_should_succeed_with_all() {
     mock_request(|builder| {
         builder


### PR DESCRIPTION
Makes it possible to specify a custom response size estimate for any Candid-RPC method. This also gives us a way to add more configuration options (e.g. consensus/agreement policy) in a backwards-compatible manner. 
