### PR TITLE
auth: remove ability for `Auth::Manage` principal to change provider ownership

### DIFF
--- a/src/providers.rs
+++ b/src/providers.rs
@@ -217,9 +217,7 @@ pub fn do_unregister_provider(caller: Principal, is_controller: bool, provider_i
     PROVIDERS.with(|providers| {
         let mut providers = providers.borrow_mut();
         if let Some(provider) = providers.get(&provider_id) {
-            if !(provider.owner == caller || is_controller) {
-                ic_cdk::trap("You are not authorized: check provider owner");
-            } else {
+            if provider.owner == caller || is_controller {
                 log!(
                     INFO,
                     "[{}] Unregistering provider: {:?}",
@@ -227,6 +225,8 @@ pub fn do_unregister_provider(caller: Principal, is_controller: bool, provider_i
                     provider_id
                 );
                 providers.remove(&provider_id).is_some()
+            } else {
+                ic_cdk::trap("You are not authorized: check provider owner");
             }
         } else {
             false
@@ -240,9 +240,7 @@ pub fn do_update_provider(caller: Principal, is_controller: bool, args: UpdatePr
         let mut providers = providers.borrow_mut();
         match providers.get(&args.provider_id) {
             Some(mut provider) => {
-                if !(provider.owner == caller || is_controller) {
-                    ic_cdk::trap("You are not authorized: check provider owner");
-                } else {
+                if provider.owner == caller || is_controller {
                     log!(INFO, "[{}] Updating provider: {}", caller, args.provider_id);
                     if let Some(hostname) = args.hostname {
                         validate_hostname(&hostname).unwrap();
@@ -263,6 +261,8 @@ pub fn do_update_provider(caller: Principal, is_controller: bool, args: UpdatePr
                         provider.cycles_per_message_byte = cycles_per_message_byte;
                     }
                     providers.insert(args.provider_id, provider);
+                } else {
+                    ic_cdk::trap("You are not authorized: check provider owner");
                 }
             }
             None => ic_cdk::trap("Provider not found"),

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -217,7 +217,7 @@ pub fn do_unregister_provider(caller: Principal, provider_id: u64) -> bool {
     PROVIDERS.with(|providers| {
         let mut providers = providers.borrow_mut();
         if let Some(provider) = providers.get(&provider_id) {
-            if provider.owner != caller && !is_authorized(&caller, Auth::Manage) {
+            if !(provider.owner == caller || is_authorized(&caller, Auth::Manage)) {
                 ic_cdk::trap("You are not authorized");
             } else {
                 log!(

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -217,7 +217,7 @@ pub fn do_unregister_provider(caller: Principal, provider_id: u64) -> bool {
     PROVIDERS.with(|providers| {
         let mut providers = providers.borrow_mut();
         if let Some(provider) = providers.get(&provider_id) {
-            if provider.owner != caller {
+            if provider.owner != caller && !is_authorized(&caller, Auth::Manage) {
                 ic_cdk::trap("You are not authorized");
             } else {
                 log!(
@@ -276,9 +276,6 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
         let mut providers = providers.borrow_mut();
         match providers.get(&args.provider_id) {
             Some(mut provider) => {
-                if let Some(owner) = args.owner {
-                    provider.owner = owner;
-                }
                 if let Some(primary) = args.primary {
                     provider.primary = primary;
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -399,7 +399,6 @@ pub struct UpdateProviderArgs {
 pub struct ManageProviderArgs {
     #[serde(rename = "providerId")]
     pub provider_id: u64,
-    pub owner: Option<Principal>,
     pub primary: Option<bool>,
     pub service: Option<RpcService>,
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -729,8 +729,8 @@ fn should_panic_if_unauthorized_unregister_provider() {
 
 #[test]
 #[should_panic(expected = "You are not authorized")]
-fn should_panic_if_manage_auth_unregister_provider() {
-    let setup = EvmRpcSetup::new().authorize_caller(Auth::Manage);
+fn should_panic_if_manage_auth_register_provider() {
+    let setup = EvmRpcSetup::new().authorize_caller(Auth::RegisterProvider);
     setup.unregister_provider(3);
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -688,8 +688,7 @@ fn should_panic_if_unauthorized_manage_provider() {
     let setup = EvmRpcSetup::new();
     setup.manage_provider(ManageProviderArgs {
         provider_id: 2,
-        owner: Some(setup.caller.0),
-        primary: None,
+        primary: Some(true),
         service: None,
     });
 }
@@ -700,8 +699,7 @@ fn should_panic_if_anonymous_manage_provider() {
     let setup = EvmRpcSetup::new().as_anonymous();
     setup.manage_provider(ManageProviderArgs {
         provider_id: 3,
-        owner: Some(setup.caller.0),
-        primary: None,
+        primary: Some(true),
         service: None,
     });
 }
@@ -759,43 +757,6 @@ fn should_panic_if_manage_auth_update_non_owned_provider() {
 }
 
 #[test]
-fn should_change_provider_owner() {
-    let mut setup = EvmRpcSetup::new().authorize_caller(Auth::RegisterProvider);
-    let provider_id = setup.register_provider(RegisterProviderArgs {
-        chain_id: 123,
-        hostname: "example.com".to_string(),
-        credential_path: "".to_string(),
-        credential_headers: None,
-        cycles_per_call: 0,
-        cycles_per_message_byte: 0,
-    });
-    setup = setup.as_controller();
-    setup.manage_provider(ManageProviderArgs {
-        provider_id,
-        owner: Some(setup.controller.0),
-        primary: None,
-        service: None,
-    });
-    assert_eq!(
-        setup
-            .get_providers()
-            .into_iter()
-            .find(|p| p.provider_id == provider_id)
-            .unwrap()
-            .owner,
-        setup.controller.0
-    );
-    setup.update_provider(UpdateProviderArgs {
-        provider_id,
-        hostname: Some("authorized.host".to_string()),
-        credential_path: None,
-        credential_headers: None,
-        cycles_per_call: None,
-        cycles_per_message_byte: None,
-    });
-}
-
-#[test]
 fn should_replace_service_provider() {
     let setup = EvmRpcSetup::new()
         .authorize_caller(Auth::RegisterProvider)
@@ -813,8 +774,7 @@ fn should_replace_service_provider() {
         .as_controller()
         .manage_provider(ManageProviderArgs {
             provider_id,
-            owner: None,
-            primary: None,
+            primary: Some(true),
             service: Some(RpcService::EthMainnet(EthMainnetService::Ankr)),
         });
     let result = setup
@@ -873,7 +833,6 @@ fn should_set_primary_provider() {
         .as_controller()
         .manage_provider(ManageProviderArgs {
             provider_id,
-            owner: None,
             primary: Some(true),
             service: None,
         });


### PR DESCRIPTION
Follow-up from the implementation review.