### PR TITLE
test: show all errors at end of Motoko E2E tests

### DIFF
--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -201,7 +201,7 @@ shared ({ caller = installer }) actor class Main() {
         if (errors.size() > 0) {
             var message = "Errors:";
             for (error in errors.vals()) {
-                message #= "\n * " # error;
+                message #= "\n* " # error;
             };
             Debug.trap(message);
         }

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -198,10 +198,12 @@ shared ({ caller = installer }) actor class Main() {
             );
         };
 
-        var message = "Errors:";
-        for (error in errors.vals()) {
-            message #= "\n * " # error;
-        };
-        Debug.trap(message);
+        if (errors.size() > 0) {
+            var message = "Errors:";
+            for (error in errors.vals()) {
+                message #= "\n * " # error;
+            };
+            Debug.trap(message);
+        }
     };
 };


### PR DESCRIPTION
Changes the Motoko E2E test to run all tests and then show a summary of errors.