### PR TITLE
fix: use exact formula for HTTP outcall cost calculation

### DIFF
--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -19,7 +19,7 @@ shared ({ caller = installer }) actor class Main() {
 
         let canisterDetails = [
             // (`canister module`, `canister type`, `nodes in subnet`, `expected cycles for JSON-RPC call`)
-            (EvmRpcCanister, "default", 13, 61_898_400),
+            (EvmRpcCanister, "default", 13, 99_330_400),
             (EvmRpcFidicuaryCanister, "fiduciary", 28, 133_319_630),
         ];
         for ((canister, canisterType, nodesInSubnet, expectedCycles) in canisterDetails.vals()) {

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -20,7 +20,7 @@ shared ({ caller = installer }) actor class Main() {
         let canisterDetails = [
             // (`canister module`, `canister type`, `nodes in subnet`, `expected cycles for JSON-RPC call`)
             (EvmRpcCanister, "default", 13, 99_330_400),
-            (EvmRpcFidicuaryCanister, "fiduciary", 28, 133_319_630),
+            (EvmRpcFidicuaryCanister, "fiduciary", 28, 239_142_400),
         ];
         for ((canister, canisterType, nodesInSubnet, expectedCycles) in canisterDetails.vals()) {
             Debug.print("Testing " # canisterType # " canister...");

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -87,10 +87,7 @@ fn test_request_cost() {
                 * nodes_in_subnet as u128
                 / NODES_IN_DEFAULT_SUBNET as u128;
         // Request body with 10 additional bytes should be within 1 cycle of expected cost (due to rounding)
-        assert_matches::assert_matches!(
-            base_cost_10_extra_bytes - estimated_cost_10_extra_bytes,
-            0 | 1
-        );
+        assert_eq!(base_cost_10_extra_bytes, estimated_cost_10_extra_bytes,);
     }
 }
 
@@ -165,7 +162,7 @@ fn test_candid_rpc_cost() {
             get_candid_rpc_cost(&provider, 123, 4567890),
             get_candid_rpc_cost(&provider, 890, 4567890),
         ],
-        [51064987, 54828787, 47559605587, 47575098987]
+        [87008987, 93724787, 47598501587, 47632402987]
     );
 
     // Fiduciary subnet
@@ -177,6 +174,6 @@ fn test_candid_rpc_cost() {
             get_candid_rpc_cost(&provider, 123, 4567890),
             get_candid_rpc_cost(&provider, 890, 4567890),
         ],
-        [109986125, 118092772, 102436073572, 102469443972]
+        [212603972, 227068772, 102545049572, 102618067972]
     );
 }

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -39,12 +39,14 @@ pub fn get_http_request_cost(
     let ingress_bytes = payload_size_bytes as u128
         + u32::max(RPC_URL_MIN_COST_BYTES, api.url.len() as u32) as u128
         + INGRESS_OVERHEAD_BYTES;
-    let base_cost = INGRESS_MESSAGE_RECEIVED_COST
+    let cost_per_node = INGRESS_MESSAGE_RECEIVED_COST
         + INGRESS_MESSAGE_BYTE_RECEIVED_COST * ingress_bytes
         + HTTP_OUTCALL_REQUEST_BASE_COST
+        + HTTP_OUTCALL_REQUEST_PER_NODE_COST * nodes_in_subnet as u128
         + HTTP_OUTCALL_REQUEST_COST_PER_BYTE * payload_size_bytes as u128
-        + HTTP_OUTCALL_RESPONSE_COST_PER_BYTE * max_response_bytes as u128;
-    base_cost * (nodes_in_subnet as u128) / NODES_IN_DEFAULT_SUBNET as u128
+        + HTTP_OUTCALL_RESPONSE_COST_PER_BYTE * max_response_bytes as u128
+        + CANISTER_OVERHEAD;
+    cost_per_node * (nodes_in_subnet as u128)
 }
 
 /// Calculate the additional cost for calling a registered JSON-RPC provider.

--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -84,9 +84,7 @@ fn test_request_cost() {
         );
         let estimated_cost_10_extra_bytes = base_cost
             + 10 * (INGRESS_MESSAGE_BYTE_RECEIVED_COST + HTTP_OUTCALL_REQUEST_COST_PER_BYTE)
-                * nodes_in_subnet as u128
-                / NODES_IN_DEFAULT_SUBNET as u128;
-        // Request body with 10 additional bytes should be within 1 cycle of expected cost (due to rounding)
+                * nodes_in_subnet as u128;
         assert_eq!(base_cost_10_extra_bytes, estimated_cost_10_extra_bytes,);
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,11 +1,17 @@
 use cketh_common::eth_rpc_client::providers::{EthMainnetService, EthSepoliaService};
 
+// HTTP outcall cost calculation
+// See https://internetcomputer.org/docs/current/developer-docs/gas-cost#cycles-price-breakdown
 pub const INGRESS_OVERHEAD_BYTES: u128 = 100;
 pub const INGRESS_MESSAGE_RECEIVED_COST: u128 = 1_200_000;
 pub const INGRESS_MESSAGE_BYTE_RECEIVED_COST: u128 = 2_000;
-pub const HTTP_OUTCALL_REQUEST_BASE_COST: u128 = 49_140_000;
-pub const HTTP_OUTCALL_REQUEST_COST_PER_BYTE: u128 = 5_200;
-pub const HTTP_OUTCALL_RESPONSE_COST_PER_BYTE: u128 = 10_400;
+pub const HTTP_OUTCALL_REQUEST_BASE_COST: u128 = 3_000_000;
+pub const HTTP_OUTCALL_REQUEST_PER_NODE_COST: u128 = 60_000;
+pub const HTTP_OUTCALL_REQUEST_COST_PER_BYTE: u128 = 400;
+pub const HTTP_OUTCALL_RESPONSE_COST_PER_BYTE: u128 = 800;
+
+// Additional cost of operating the canister per subnet node
+pub const CANISTER_OVERHEAD: u128 = 1_000_000;
 
 // Minimum number of bytes charged for a URL; improves consistency of costs between providers
 pub const RPC_URL_MIN_COST_BYTES: u32 = 256;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,7 @@
 use cketh_common::eth_rpc_client::providers::{EthMainnetService, EthSepoliaService};
 
 // HTTP outcall cost calculation
-// See https://internetcomputer.org/docs/current/developer-docs/gas-cost#cycles-price-breakdown
+// See https://internetcomputer.org/docs/current/developer-docs/gas-cost#special-features
 pub const INGRESS_OVERHEAD_BYTES: u128 = 100;
 pub const INGRESS_MESSAGE_RECEIVED_COST: u128 = 1_200_000;
 pub const INGRESS_MESSAGE_BYTE_RECEIVED_COST: u128 = 2_000;


### PR DESCRIPTION
The original Ethereum integration and ckETH cycles calculation logic used a linear approximation of the HTTP outcall cycles cost calculation. This PR uses the exact formula, which includes a quadratic term: 

`((3M + 60K * nodes_in_subnet) + 400 * request_size + 800 * max_response) * nodes_in_subnet`

I also added a link to the (somewhat difficult-to-find) documentation page knowing that some community members are using this code as reference for calculating HTTP outcall costs.