### PR TITLE
candid: remove ability to specify RPC service by hostname

### DIFF
--- a/candid/evm_rpc.did
+++ b/candid/evm_rpc.did
@@ -71,7 +71,6 @@ type InitArgs = record {
 type JsonRpcError = record { code : int64; message : text };
 type JsonRpcSource = variant {
   Custom : record { url : text; headers : opt vec HttpHeader };
-  Service : record { hostname : text; chainId : opt nat64 };
   Chain : nat64;
   Provider : nat64;
 };

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,11 +27,6 @@ pub struct InitArgs {
 pub enum JsonRpcSource {
     Chain(u64),
     Provider(u64),
-    Service {
-        hostname: String,
-        #[serde(rename = "chainId")]
-        chain_id: Option<u64>,
-    },
     Custom {
         url: String,
         headers: Option<Vec<HttpHeader>>,
@@ -60,24 +55,6 @@ impl JsonRpcSource {
                         .iter()
                         .find(|(_, p)| p.primary && p.chain_id == id)
                         .or_else(|| providers.iter().find(|(_, p)| p.chain_id == id))
-                        .ok_or(ProviderError::ProviderNotFound)?
-                        .1)
-                })?)
-            }
-            JsonRpcSource::Service { hostname, chain_id } => {
-                ResolvedJsonRpcSource::Provider(PROVIDERS.with(|providers| {
-                    let matches_provider = |p: &Provider| {
-                        p.hostname == hostname
-                            && match chain_id {
-                                Some(id) => p.chain_id == id,
-                                None => true,
-                            }
-                    };
-                    let providers = providers.borrow();
-                    Ok(providers
-                        .iter()
-                        .find(|(_, p)| p.primary && matches_provider(p))
-                        .or_else(|| providers.iter().find(|(_, p)| matches_provider(p)))
                         .ok_or(ProviderError::ProviderNotFound)?
                         .1)
                 })?)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -852,9 +852,13 @@ fn should_set_primary_provider() {
     assert_matches!(
         setup
             .request(
-                JsonRpcSource::Service {
-                    hostname: ALCHEMY_ETH_MAINNET_HOSTNAME.to_string(),
-                    chain_id: None,
+                JsonRpcSource::Custom {
+                    url: format!(
+                        "https://{}{}",
+                        ALCHEMY_ETH_MAINNET_HOSTNAME.to_string(),
+                        ALCHEMY_ETH_MAINNET_CREDENTIAL.to_string()
+                    ),
+                    headers: None,
                 },
                 MOCK_REQUEST_PAYLOAD,
                 MOCK_REQUEST_RESPONSE_BYTES,
@@ -880,9 +884,13 @@ fn should_set_primary_provider() {
     assert_matches!(
         setup
             .request(
-                JsonRpcSource::Service {
-                    hostname: ALCHEMY_ETH_MAINNET_HOSTNAME.to_string(),
-                    chain_id: None,
+                JsonRpcSource::Custom {
+                    url: format!(
+                        "https://{}{}",
+                        ALCHEMY_ETH_MAINNET_HOSTNAME.to_string(),
+                        ALCHEMY_ETH_MAINNET_CREDENTIAL.to_string()
+                    ),
+                    headers: None,
                 },
                 MOCK_REQUEST_PAYLOAD,
                 MOCK_REQUEST_RESPONSE_BYTES,


### PR DESCRIPTION
Follow-up from the implementation review. 
