### PR TITLE
auth: misc. adjustments and refactoring

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -12,7 +12,7 @@ pub fn is_authorized(principal: &Principal, auth: Auth) -> bool {
     })
 }
 
-pub fn require_admin_or_controller() -> Result<(), String> {
+pub fn require_manage_or_controller() -> Result<(), String> {
     let caller = ic_cdk::caller();
     if is_authorized(&caller, Auth::Manage) || ic_cdk::api::is_controller(&caller) {
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ fn update_provider(provider: UpdateProviderArgs) {
     do_update_provider(caller, is_controller(&caller), provider)
 }
 
-#[update(name = "manageProvider", guard = "require_admin_or_controller")]
+#[update(name = "manageProvider", guard = "require_manage_or_controller")]
 #[candid_method(rename = "manageProvider")]
 fn manage_provider(args: ManageProviderArgs) {
     log!(
@@ -172,7 +172,7 @@ fn manage_provider(args: ManageProviderArgs) {
     do_manage_provider(args)
 }
 
-#[query(name = "getServiceProviderMap", guard = "require_admin_or_controller")]
+#[query(name = "getServiceProviderMap", guard = "require_manage_or_controller")]
 #[candid_method(query, rename = "getServiceProviderMap")]
 fn get_service_provider_map() -> Vec<(RpcService, u64)> {
     SERVICE_PROVIDER_MAP.with(|map| {
@@ -302,12 +302,12 @@ fn get_metrics() -> Metrics {
     UNSTABLE_METRICS.with(|metrics| (*metrics.borrow()).clone())
 }
 
-#[query(guard = "require_admin_or_controller")]
+#[query(name = "stableSize", guard = "require_manage_or_controller")]
 fn stable_size() -> u64 {
     ic_cdk::api::stable::stable64_size() * WASM_PAGE_SIZE
 }
 
-#[query(guard = "require_admin_or_controller")]
+#[query(name = "stableRead", guard = "require_manage_or_controller")]
 fn stable_read(offset: u64, length: u64) -> Vec<u8> {
     let mut buffer = Vec::new();
     buffer.resize(length as usize, 0);
@@ -315,7 +315,7 @@ fn stable_read(offset: u64, length: u64) -> Vec<u8> {
     buffer
 }
 
-#[update(guard = "require_admin_or_controller")]
+#[update(guard = "require_manage_or_controller")]
 #[candid_method]
 fn authorize(principal: Principal, auth: Auth) -> bool {
     log!(
@@ -328,7 +328,7 @@ fn authorize(principal: Principal, auth: Auth) -> bool {
     do_authorize(principal, auth)
 }
 
-#[query(name = "getAuthorized", guard = "require_admin_or_controller")]
+#[query(name = "getAuthorized", guard = "require_manage_or_controller")]
 #[candid_method(query, rename = "getAuthorized")]
 fn get_authorized(auth: Auth) -> Vec<Principal> {
     AUTH.with(|a| {
@@ -342,7 +342,7 @@ fn get_authorized(auth: Auth) -> Vec<Principal> {
     })
 }
 
-#[update(guard = "require_admin_or_controller")]
+#[update(guard = "require_manage_or_controller")]
 #[candid_method]
 fn deauthorize(principal: Principal, auth: Auth) -> bool {
     log!(
@@ -355,13 +355,13 @@ fn deauthorize(principal: Principal, auth: Auth) -> bool {
     do_deauthorize(principal, auth)
 }
 
-#[query(name = "getOpenRpcAccess", guard = "require_admin_or_controller")]
+#[query(name = "getOpenRpcAccess", guard = "require_manage_or_controller")]
 #[candid_method(query, rename = "getOpenRpcAccess")]
 fn get_open_rpc_access() -> bool {
     METADATA.with(|m| m.borrow().get().open_rpc_access)
 }
 
-#[update(name = "setOpenRpcAccess", guard = "require_admin_or_controller")]
+#[update(name = "setOpenRpcAccess", guard = "require_manage_or_controller")]
 #[candid_method(rename = "setOpenRpcAccess")]
 fn set_open_rpc_access(open_rpc_access: bool) {
     log!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,13 +188,15 @@ fn get_service_provider_map() -> Vec<(RpcService, u64)> {
 #[query(name = "getAccumulatedCycleCount")]
 #[candid_method(query, rename = "getAccumulatedCycleCount")]
 fn get_accumulated_cycle_count(provider_id: u64) -> u128 {
-    do_get_accumulated_cycle_count(ic_cdk::caller(), provider_id)
+    let caller = ic_cdk::caller();
+    do_get_accumulated_cycle_count(caller, is_controller(&caller), provider_id)
 }
 
 #[update(name = "withdrawAccumulatedCycles")]
 #[candid_method(rename = "withdrawAccumulatedCycles")]
 async fn withdraw_accumulated_cycles(provider_id: u64, canister_id: Principal) {
-    do_withdraw_accumulated_cycles(ic_cdk::caller(), provider_id, canister_id).await
+    let caller = ic_cdk::caller();
+    do_withdraw_accumulated_cycles(caller, is_controller(&caller), provider_id, canister_id).await
 }
 
 #[query(name = "__transform_json_rpc")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
-use candid::{candid_method, CandidType};
-use cketh_common::eth_rpc::{
-    Block, FeeHistory, LogEntry, ProviderError, RpcError, SendRawTransactionResult,
-};
+use candid::candid_method;
+use cketh_common::eth_rpc::{Block, FeeHistory, LogEntry, RpcError, SendRawTransactionResult};
 
 use cketh_common::eth_rpc_client::providers::RpcService;
 use cketh_common::eth_rpc_client::RpcConfig;

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,13 +188,13 @@ fn get_service_provider_map() -> Vec<(RpcService, u64)> {
 #[query(name = "getAccumulatedCycleCount")]
 #[candid_method(query, rename = "getAccumulatedCycleCount")]
 fn get_accumulated_cycle_count(provider_id: u64) -> u128 {
-    do_get_accumulated_cycle_count(ic_cdk::caller())
+    do_get_accumulated_cycle_count(ic_cdk::caller(), provider_id)
 }
 
 #[update(name = "withdrawAccumulatedCycles")]
 #[candid_method(rename = "withdrawAccumulatedCycles")]
 async fn withdraw_accumulated_cycles(provider_id: u64, canister_id: Principal) {
-    do_withdraw_accumulated_cycles(ic_cdk::caller(), provider_id, canister_id)
+    do_withdraw_accumulated_cycles(ic_cdk::caller(), provider_id, canister_id).await
 }
 
 #[query(name = "__transform_json_rpc")]

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -290,7 +290,11 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
     })
 }
 
-pub fn do_get_accumulated_cycle_count(caller: Principal, provider_id: u64) -> u128 {
+pub fn do_get_accumulated_cycle_count(
+    caller: Principal,
+    is_controller: bool,
+    provider_id: u64,
+) -> u128 {
     let provider = PROVIDERS
         .with(|p| {
             p.borrow()
@@ -298,14 +302,16 @@ pub fn do_get_accumulated_cycle_count(caller: Principal, provider_id: u64) -> u1
                 .ok_or(ProviderError::ProviderNotFound)
         })
         .expect("Provider not found");
-    if caller != provider.owner {
+    if caller == provider.owner || is_controller {
+        provider.cycles_owed
+    } else {
         ic_cdk::trap("You are not authorized: check provider owner");
     }
-    provider.cycles_owed
 }
 
 pub async fn do_withdraw_accumulated_cycles(
     caller: Principal,
+    is_controller: bool,
     provider_id: u64,
     canister_id: Principal,
 ) {
@@ -316,61 +322,62 @@ pub async fn do_withdraw_accumulated_cycles(
                 .ok_or(ProviderError::ProviderNotFound)
         })
         .expect("Provider not found");
-    if caller != provider.owner {
+    if caller == provider.owner || is_controller {
+        let amount = provider.cycles_owed;
+        if amount < MINIMUM_WITHDRAWAL_CYCLES {
+            ic_cdk::trap("Too few cycles to withdraw");
+        }
+        PROVIDERS.with(|p| {
+            provider.cycles_owed = 0;
+            p.borrow_mut().insert(provider_id, provider)
+        });
+        log!(
+            INFO,
+            "[{}] Withdrawing {} cycles from provider {} to canister: {}",
+            caller,
+            amount,
+            provider_id,
+            canister_id,
+        );
+        #[derive(CandidType)]
+        struct DepositCyclesArgs {
+            canister_id: Principal,
+        }
+        match ic_cdk::api::call::call_with_payment128(
+            Principal::management_canister(),
+            "deposit_cycles",
+            (DepositCyclesArgs { canister_id },),
+            amount,
+        )
+        .await
+        {
+            Ok(()) => add_metric!(cycles_withdrawn, amount),
+            Err(err) => {
+                // Refund on failure to send cycles
+                log!(
+                    INFO,
+                    "[{}] Unable to send {} cycles from provider {}: {:?}",
+                    canister_id,
+                    amount,
+                    provider_id,
+                    err
+                );
+                // Protect against re-entrancy
+                let provider = PROVIDERS.with(|p| {
+                    p.borrow()
+                        .get(&provider_id)
+                        .ok_or(ProviderError::ProviderNotFound)
+                });
+                let mut provider = provider.expect("Provider not found during refund, cycles lost");
+                PROVIDERS.with(|p| {
+                    provider.cycles_owed += amount;
+                    p.borrow_mut().insert(provider_id, provider)
+                });
+            }
+        };
+    } else {
         ic_cdk::trap("You are not authorized: check provider owner");
     }
-    let amount = provider.cycles_owed;
-    if amount < MINIMUM_WITHDRAWAL_CYCLES {
-        ic_cdk::trap("Too few cycles to withdraw");
-    }
-    PROVIDERS.with(|p| {
-        provider.cycles_owed = 0;
-        p.borrow_mut().insert(provider_id, provider)
-    });
-    log!(
-        INFO,
-        "[{}] Withdrawing {} cycles from provider {} to canister: {}",
-        caller,
-        amount,
-        provider_id,
-        canister_id,
-    );
-    #[derive(CandidType)]
-    struct DepositCyclesArgs {
-        canister_id: Principal,
-    }
-    match ic_cdk::api::call::call_with_payment128(
-        Principal::management_canister(),
-        "deposit_cycles",
-        (DepositCyclesArgs { canister_id },),
-        amount,
-    )
-    .await
-    {
-        Ok(()) => add_metric!(cycles_withdrawn, amount),
-        Err(err) => {
-            // Refund on failure to send cycles
-            log!(
-                INFO,
-                "[{}] Unable to send {} cycles from provider {}: {:?}",
-                canister_id,
-                amount,
-                provider_id,
-                err
-            );
-            // Protect against re-entrancy
-            let provider = PROVIDERS.with(|p| {
-                p.borrow()
-                    .get(&provider_id)
-                    .ok_or(ProviderError::ProviderNotFound)
-            });
-            let mut provider = provider.expect("Provider not found during refund, cycles lost");
-            PROVIDERS.with(|p| {
-                provider.cycles_owed += amount;
-                p.borrow_mut().insert(provider_id, provider)
-            });
-        }
-    };
 }
 
 pub fn set_service_provider(service: &RpcService, provider: &Provider) {

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1,3 +1,4 @@
+use candid::CandidType;
 use cketh_common::{
     eth_rpc::ProviderError,
     eth_rpc_client::providers::{EthMainnetService, EthSepoliaService, RpcService},
@@ -289,7 +290,7 @@ pub fn do_manage_provider(args: ManageProviderArgs) {
     })
 }
 
-pub fn do_get_accumulated_cycle_count(caller: Principal) -> u128 {
+pub fn do_get_accumulated_cycle_count(caller: Principal, provider_id: u64) -> u128 {
     let provider = PROVIDERS
         .with(|p| {
             p.borrow()
@@ -303,8 +304,12 @@ pub fn do_get_accumulated_cycle_count(caller: Principal) -> u128 {
     provider.cycles_owed
 }
 
-pub fn do_withdraw_accumulated_cycles(caller: Principal, provider_id: u64, canister_id: Principal) {
-    let provider = PROVIDERS
+pub async fn do_withdraw_accumulated_cycles(
+    caller: Principal,
+    provider_id: u64,
+    canister_id: Principal,
+) {
+    let mut provider = PROVIDERS
         .with(|p| {
             p.borrow()
                 .get(&provider_id)
@@ -330,6 +335,10 @@ pub fn do_withdraw_accumulated_cycles(caller: Principal, provider_id: u64, canis
         provider_id,
         canister_id,
     );
+    #[derive(CandidType)]
+    struct DepositCyclesArgs {
+        canister_id: Principal,
+    }
     match ic_cdk::api::call::call_with_payment128(
         Principal::management_canister(),
         "deposit_cycles",
@@ -340,7 +349,7 @@ pub fn do_withdraw_accumulated_cycles(caller: Principal, provider_id: u64, canis
     {
         Ok(()) => add_metric!(cycles_withdrawn, amount),
         Err(err) => {
-            // Refund on failure to send cycles.
+            // Refund on failure to send cycles
             log!(
                 INFO,
                 "[{}] Unable to send {} cycles from provider {}: {:?}",
@@ -349,12 +358,13 @@ pub fn do_withdraw_accumulated_cycles(caller: Principal, provider_id: u64, canis
                 provider_id,
                 err
             );
+            // Protect against re-entrancy
             let provider = PROVIDERS.with(|p| {
                 p.borrow()
                     .get(&provider_id)
                     .ok_or(ProviderError::ProviderNotFound)
             });
-            let mut provider = provider.expect("Provider not found during refund, cycles lost.");
+            let mut provider = provider.expect("Provider not found during refund, cycles lost");
             PROVIDERS.with(|p| {
                 provider.cycles_owed += amount;
                 p.borrow_mut().insert(provider_id, provider)


### PR DESCRIPTION
* Finishes some leftover refactoring from the original Ethereum integration canister.
* Drops the requirement for the `RegisterProvider` permission and allows controller principals to withdraw cycles, making this equivalent to other methods with ownership-based authorization.
* Renames stable memory access methods for consistency with the public methods in the Candid interface.
* Renames guard `require_admin_or_controller` to `require_manage_or_controller`.
