### PR TITLE
feat: set up production canister

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,20 +67,8 @@ jobs:
       - name: Install npm packages
         run: npm ci
 
-      - name: Deploy EVM RPC
-        run: dfx deploy evm_rpc --argument "(record {nodesInSubnet = 13})"
-
-      - name: Deploy EVM RPC fiduciary canister
-        run: dfx deploy evm_rpc_fiduciary --argument "(record {nodesInSubnet = 28})"
-
-      - name: Generate language bindings
-        run: npm run generate
-
-      - name: Test (Motoko)
-        run: dfx deploy e2e_motoko && dfx canister call e2e_motoko test
-
-      - name: Test (Rust)
-        run: dfx deploy e2e_rust && dfx canister call e2e_rust test
-
+      - name: Run E2E tests
+        run: scripts/e2e
+      
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install dfx
-        run: |
-          wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-          bash install-dfx.sh < <(yes Y)
-          rm install-dfx.sh
-          dfx cache install
-          echo "$HOME/bin" >> $GITHUB_PATH
+        uses: dfinity/setup-dfx@main
 
       - name: Start dfx
         run: dfx start --background
@@ -69,6 +64,9 @@ jobs:
 
       - name: Run E2E tests
         run: scripts/e2e
+
+      - name: Run examples
+        run: scripts/examples
       
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Beyond the Ethereum blockchain, this canister also has partial support for Polyg
 
 ## Canisters
 
+* Production canisters (API keys managed by DFINITY):
+  * Fiduciary subnet (28 nodes): [`7hfb6-caaaa-aaaar-qadga-cai`](https://dashboard.internetcomputer.org/canister/7hfb6-caaaa-aaaar-qadga-cai)
+
 * Test canisters (no API keys):
   * Standard subnet (13 nodes): [`a6d44-nyaaa-aaaap-abp7q-cai`](https://dashboard.internetcomputer.org/canister/a6d44-nyaaa-aaaap-abp7q-cai)
   * Fiduciary subnet (28 nodes): [`xhcuo-6yaaa-aaaar-qacqq-cai`](https://dashboard.internetcomputer.org/canister/xhcuo-6yaaa-aaaar-qacqq-cai)

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -5,10 +5,13 @@
   "e2e_rust": {
     "ic": "rlgcw-7aaaa-aaaap-abupa-cai"
   },
-  "evm_rpc": {
+  "evm_rpc_staging": {
     "ic": "a6d44-nyaaa-aaaap-abp7q-cai"
   },
-  "evm_rpc_fiduciary": {
+  "evm_rpc_staging_fiduciary": {
     "ic": "xhcuo-6yaaa-aaaar-qacqq-cai"
+  },
+  "evm_rpc": {
+    "ic": "7hfb6-caaaa-aaaar-qadga-cai"
   }
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -5,13 +5,13 @@
   "e2e_rust": {
     "ic": "rlgcw-7aaaa-aaaap-abupa-cai"
   },
-  "evm_rpc_staging": {
+  "evm_rpc": {
+    "ic": "7hfb6-caaaa-aaaar-qadga-cai"
+  },
+  "evm_rpc_staging_13_node": {
     "ic": "a6d44-nyaaa-aaaap-abp7q-cai"
   },
   "evm_rpc_staging_fiduciary": {
     "ic": "xhcuo-6yaaa-aaaar-qacqq-cai"
-  },
-  "evm_rpc": {
-    "ic": "7hfb6-caaaa-aaaar-qadga-cai"
   }
 }

--- a/dfx.json
+++ b/dfx.json
@@ -20,13 +20,21 @@
       "package": "evm_rpc"
     },
     "e2e_rust": {
-      "dependencies": ["evm_rpc_staging_13_node", "evm_rpc_staging_fiduciary"],
+      "dependencies": [
+        "evm_rpc",
+        "evm_rpc_staging_13_node",
+        "evm_rpc_staging_fiduciary"
+      ],
       "candid": "e2e/rust/e2e_rust.did",
       "type": "rust",
       "package": "e2e"
     },
     "e2e_motoko": {
-      "dependencies": ["evm_rpc_staging_13_node", "evm_rpc_staging_fiduciary"],
+      "dependencies": [
+        "evm_rpc",
+        "evm_rpc_staging_13_node",
+        "evm_rpc_staging_fiduciary"
+      ],
       "type": "motoko",
       "main": "e2e/motoko/Main.mo"
     }

--- a/dfx.json
+++ b/dfx.json
@@ -9,19 +9,24 @@
         "output": "lib/motoko/src/declarations"
       }
     },
-    "evm_rpc_fiduciary": {
+    "evm_rpc_staging_13_node": {
+      "candid": "candid/evm_rpc.did",
+      "type": "rust",
+      "package": "evm_rpc"
+    },
+    "evm_rpc_staging_fiduciary": {
       "candid": "candid/evm_rpc.did",
       "type": "rust",
       "package": "evm_rpc"
     },
     "e2e_rust": {
-      "dependencies": ["evm_rpc", "evm_rpc_fiduciary"],
+      "dependencies": ["evm_rpc_staging_13_node", "evm_rpc_staging_fiduciary"],
       "candid": "e2e/rust/e2e_rust.did",
       "type": "rust",
       "package": "e2e"
     },
     "e2e_motoko": {
-      "dependencies": ["evm_rpc", "evm_rpc_fiduciary"],
+      "dependencies": ["evm_rpc_staging_13_node", "evm_rpc_staging_fiduciary"],
       "type": "motoko",
       "main": "e2e/motoko/Main.mo"
     }

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -1,5 +1,5 @@
-import EvmRpcCanister "canister:evm_rpc";
-import EvmRpcFidicuaryCanister "canister:evm_rpc_fiduciary";
+import EvmRpc13Node "canister:evm_rpc_staging_13_node";
+import EvmRpcFidicuary "canister:evm_rpc_staging_fiduciary";
 
 import Blob "mo:base/Blob";
 import Debug "mo:base/Debug";
@@ -13,7 +13,7 @@ shared ({ caller = installer }) actor class Main() {
     public shared ({ caller }) func test() : async () {
         assert caller == installer;
 
-        let ignoredTests : [(EvmRpcCanister.RpcService, Text)] = [
+        let ignoredTests : [(EvmRpc13Node.RpcService, Text)] = [
             // (`RPC service`, `method`)
             (#EthMainnet(#BlockPi), "eth_sendRawTransaction"), // "Private transaction replacement (same nonce) with gas price change lower than 10% is not allowed within 30 sec from the previous transaction."
         ];
@@ -21,8 +21,8 @@ shared ({ caller = installer }) actor class Main() {
         let errors = Buffer.Buffer<Text>(0);
         let canisterDetails = [
             // (`canister module`, `canister type`, `nodes in subnet`, `expected cycles for JSON-RPC call`)
-            (EvmRpcCanister, "default", 13, 99_330_400),
-            (EvmRpcFidicuaryCanister, "fiduciary", 28, 239_142_400),
+            (EvmRpc13Node, "default", 13, 99_330_400),
+            (EvmRpcFidicuary, "fiduciary", 28, 239_142_400),
         ];
         for ((canister, canisterType, nodesInSubnet, expectedCycles) in canisterDetails.vals()) {
             Debug.print("Testing " # canisterType # " canister...");
@@ -204,6 +204,6 @@ shared ({ caller = installer }) actor class Main() {
                 message #= "\n* " # error;
             };
             Debug.trap(message);
-        }
+        };
     };
 };

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -15,12 +15,12 @@ shared ({ caller = installer }) actor class Main() {
     type TestCategory = { #staging; #production };
 
     type SubnetTarget = (Nat, Nat);
-    // (`subnet name`, `canister module`, `canister type`, `subnet`)
+    // (`nodes in subnet`, `expected cycles for JSON-RPC call`)
     let defaultSubnet = ("13-node", 13, 99_330_400);
     let fiduciarySubnet = ("fiduciary", 28, 239_142_400);
 
-    // (`nodes in subnet`, `expected cycles for JSON-RPC call`)
     let testTargets = [
+        // (`subnet name`, `canister module`, `canister type`, `subnet`)
         (EvmRpcStaging13Node, #staging, defaultSubnet),
         (EvmRpcStagingFidicuary, #staging, fiduciarySubnet),
         (EvmRpcProductionFiduciary, #production, fiduciarySubnet),

--- a/e2e/motoko/Main.mo
+++ b/e2e/motoko/Main.mo
@@ -26,6 +26,11 @@ shared ({ caller = installer }) actor class Main() {
         (EvmRpcProductionFiduciary, #production, fiduciarySubnet),
     ];
 
+    // (`RPC service`, `method`)
+    let ignoredTests = [
+        (#EthMainnet(#BlockPi), "eth_sendRawTransaction"), // "Private transaction replacement (same nonce) with gas price change lower than 10% is not allowed within 30 sec from the previous transaction."
+    ];
+
     public shared ({ caller }) func test() : async () {
         await runTests(caller, #staging);
     };
@@ -36,11 +41,6 @@ shared ({ caller = installer }) actor class Main() {
 
     func runTests(caller : Principal, category : TestCategory) : async () {
         assert caller == installer;
-
-        let ignoredTests = [
-            // (`RPC service`, `method`)
-            (#EthMainnet(#BlockPi), "eth_sendRawTransaction"), // "Private transaction replacement (same nonce) with gas price change lower than 10% is not allowed within 30 sec from the previous transaction."
-        ];
 
         let errors = Buffer.Buffer<Text>(0);
         var relevantTestCount = 0;

--- a/e2e/rust/build.rs
+++ b/e2e/rust/build.rs
@@ -4,7 +4,7 @@ fn main() {
     let mut builder = Builder::new();
 
     builder.add({
-        let mut config = Config::new("evm_rpc");
+        let mut config = Config::new("evm_rpc_staging_fiduciary");
         config.binding.type_attributes =
             "#[derive(CandidType, Clone, Debug, Deserialize)]".to_string();
         config

--- a/e2e/rust/build.rs
+++ b/e2e/rust/build.rs
@@ -3,10 +3,12 @@ use ic_cdk_bindgen::{Builder, Config};
 fn main() {
     let mut builder = Builder::new();
 
-    let mut evm_rpc = Config::new("evm_rpc");
-    evm_rpc.binding.type_attributes =
-        "#[derive(CandidType, Clone, Debug, Deserialize)]".to_string();
-    builder.add(evm_rpc);
+    builder.add({
+        let mut config = Config::new("evm_rpc");
+        config.binding.type_attributes =
+            "#[derive(CandidType, Clone, Debug, Deserialize)]".to_string();
+        config
+    });
 
     builder.build(None);
 }

--- a/e2e/rust/src/main.rs
+++ b/e2e/rust/src/main.rs
@@ -1,7 +1,9 @@
 use candid::candid_method;
 use ic_cdk_macros::update;
 
-use e2e::declarations::evm_rpc::{evm_rpc, JsonRpcSource, ProviderError, RpcError};
+use e2e::declarations::evm_rpc_staging_fiduciary::{
+    evm_rpc_staging_fiduciary as evm_rpc, JsonRpcSource, ProviderError, RpcError,
+};
 
 fn main() {}
 

--- a/lib/motoko/src/lib.mo
+++ b/lib/motoko/src/lib.mo
@@ -30,7 +30,6 @@ module {
 
     type ActorSource = EvmRpc.JsonRpcSource;
 
-    public type RpcActorClass = EvmRpc.Self;
     public type RpcError = EvmRpc.RpcError;
     public type JsonRpcError = EvmRpc.JsonRpcError;
     public type ProviderError = EvmRpc.ProviderError;

--- a/lib/motoko/src/lib.mo
+++ b/lib/motoko/src/lib.mo
@@ -30,6 +30,7 @@ module {
 
     type ActorSource = EvmRpc.JsonRpcSource;
 
+    public type RpcActorClass = EvmRpc.Self;
     public type RpcError = EvmRpc.RpcError;
     public type JsonRpcError = EvmRpc.JsonRpcError;
     public type ProviderError = EvmRpc.ProviderError;

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -6,7 +6,9 @@
     dfx deploy evm_rpc_staging_13_node --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
     npm run generate &&
-    dfx deploy e2e_motoko --mode reinstall -y &&
+    dfx deploy e2e_rust &&
+    dfx canister call e2e_rust test &&
+    dfx deploy e2e_motoko &&
     dfx canister call e2e_motoko test &&
     echo Done
 )

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Reinstall all canisters and run E2E tests in your local environment.
 (
+    dfx canister create --all &&
     dfx deploy evm_rpc --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_13_node --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -6,8 +6,6 @@
     dfx deploy evm_rpc_staging_13_node --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
     npm run generate &&
-    dfx deploy e2e_rust --mode reinstall -y &&
-    dfx canister call e2e_rust test &&
     dfx deploy e2e_motoko --mode reinstall -y &&
     dfx canister call e2e_motoko test &&
     echo Done

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Reinstall all canisters and run E2E tests in your local environment.
 (
-    dfx canister create --all &&
     dfx deploy evm_rpc --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_13_node --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
     dfx deploy evm_rpc_staging_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -2,8 +2,10 @@
 # Reinstall all canisters and run E2E tests in your local environment.
 (
     dfx canister create --all &&
-    dfx deploy evm_rpc --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
-    dfx deploy evm_rpc_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
+    dfx deploy evm_rpc --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
+    dfx deploy evm_rpc_staging_13_node --argument "(record {nodesInSubnet = 13})" --mode reinstall -y &&
+    dfx deploy evm_rpc_staging_fiduciary --argument "(record {nodesInSubnet = 28})" --mode reinstall -y &&
+    npm run generate &&
     dfx deploy e2e_rust --mode reinstall -y &&
     dfx canister call e2e_rust test &&
     dfx deploy e2e_motoko --mode reinstall -y &&


### PR DESCRIPTION
Adds a production canister deployed on the fiduciary subnet with DFINITY-managed API keys. 

In addition, this PR does a significant refactor of the Motoko E2E tests to allow testing backwards compatibility on mainnet. I also included some CI changes such as running the example dfx commands as part of the `e2e` workflow.